### PR TITLE
Fix NODE_ENV not being set when running 'npm run dev'

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "heroku-postbuild": "gulp build",
     "postinstall": "shx cp -n server/config/env/secrets-template.js server/config/env/secrets.js",
-    "dev": "gulp watch",
+    "dev": "NODE_ENV=development gulp watch",
     "build": "gulp build",
     "build:server": "gulp build-server",
     "build:client": "gulp build-client",


### PR DESCRIPTION
When I run `npm run dev` it does not seem to be setting NODE_ENV=development.  For example it doesn't pick up morgan in the following code

```
  if (process.env.NODE_ENV === 'development') {
    // Enable logger (morgan)
    app.use(morgan('dev'))
```