### PR TITLE
Reply with 400 when client submits bad json

### DIFF
--- a/server/lib/errors.js
+++ b/server/lib/errors.js
@@ -78,12 +78,13 @@ export default function getErrorMessage(err) {
   }
 
   //This catches when body-parser encounters bad JSON user data in a request
-  if(err.stack.match(/^SyntaxError: Unexpected token.+in JSON(.|\n)*node_modules\/body-parser/)) {
+  if(err.stack.match(/^SyntaxError:.+in JSON(.|\n)*node_modules\/body-parser/)) {
     return {
-      message: `Bad JSON in HTTP request. ${err.message}:  ${err.body}`,
+      message: (process.env.NODE_ENV === 'production') ? 'The data received by the server is not properly formatted. Try refreshing your browser.'
+        : `Bad JSON in HTTP request. ${err.message}:  ${err.body}`,
       status: 400
     }
   }
-  
+
   return defaultResponse
 }

--- a/server/lib/errors.js
+++ b/server/lib/errors.js
@@ -77,5 +77,13 @@ export default function getErrorMessage(err) {
     }
   }
 
+  //This catches when body-parser encounters bad JSON user data in a request
+  if(err.stack.match(/^SyntaxError: Unexpected token.+in JSON(.|\n)*node_modules\/body-parser/)) {
+    return {
+      message: `Bad JSON in HTTP request. ${err.message}:  ${err.body}`,
+      status: 400
+    }
+  }
+  
   return defaultResponse
 }


### PR DESCRIPTION
If a user sends a bad json request such as  **POST /api/auth/signin  {"email": "password":}** the server responds with 500 'Something went wrong on the server'.  This changes it to reply 400 and informs there is a problem with the json the user submitted.