### PR TITLE
Uploading logo/signature should create new files and delete the old ones

### DIFF
--- a/server/controllers/media.js
+++ b/server/controllers/media.js
@@ -1,26 +1,26 @@
-import Media from '../models/media';
-import { deleteFile } from '../lib/media-helpers';
+import Media from '../models/media'
+import { deleteFile } from '../lib/media-helpers'
 
 export default {
   async read(req, res) {
-    const media = await Media.findOne();
+    const media = await Media.findOne()
     res.json(media || new Media)
   },
 
   async upload(req, res) {
-    const media = (await Media.findOne()) || new Media;
+    const media = (await Media.findOne()) || new Media
 
     Object.keys(req.files).forEach(type => {
-      const {filename} = req.files[type][0];
+      const {filename} = req.files[type][0]
 
       if (media[type] && media[type] !== filename) {
-        deleteFile(media[type]);
+        deleteFile(media[type])
       }
 
       media[type] = filename
-    });
+    })
 
-    await media.save();
+    await media.save()
     res.json(media)
   }
 }

--- a/server/controllers/media.js
+++ b/server/controllers/media.js
@@ -1,20 +1,26 @@
-import Media from '../models/media'
+import Media from '../models/media';
+import { deleteFile } from '../lib/media-helpers';
 
 export default {
   async read(req, res) {
-    const media = await Media.findOne()
+    const media = await Media.findOne();
     res.json(media || new Media)
   },
 
   async upload(req, res) {
-    const media = (await Media.findOne()) || new Media
+    const media = (await Media.findOne()) || new Media;
 
     Object.keys(req.files).forEach(type => {
-      const {filename} = req.files[type][0]
-      media[type] = filename
-    })
+      const {filename} = req.files[type][0];
 
-    await media.save()
+      if (media[type] && media[type] !== filename) {
+        deleteFile(media[type]);
+      }
+
+      media[type] = filename
+    });
+
+    await media.save();
     res.json(media)
   }
 }

--- a/server/lib/media-helpers.js
+++ b/server/lib/media-helpers.js
@@ -1,27 +1,34 @@
-import * as fs from 'fs';
-import * as path from 'path';
-import {last} from 'lodash';
-import multer from 'multer';
+import fs from 'fs'
+import path from 'path'
+import crypto from 'crypto'
+import multer from 'multer'
+import {last} from 'lodash'
 
-const mediaRoot = process.env.NODE_ENV === 'production' ? 'dist/client/media' : 'assets/media';
+const mediaRoot = process.env.NODE_ENV === 'production' ? 'dist/client/media' : 'assets/media'
 
-const getPath = (filename) => {
-    return path.resolve(`${mediaRoot}/${filename}`);
-};
+const getPath = filename => {
+  return path.resolve(`${mediaRoot}/${filename}`)
+}
+
+const generateUniqueFilename = filename => {
+  const ext = last(filename.split('.'));
+  const raw = crypto.pseudoRandomBytes(16);
+  return `${raw.toString('hex')}.${ext}`;
+}
 
 const storage = multer.diskStorage({
-    destination: function (req, file, cb) {
-        cb(null, `${mediaRoot}`)
-    },
-    filename: function (req, file, cb) {
-        const ext = last(file.originalname.split('.'));
-        cb(null, `${file.fieldname}.${ext}`)
-    }
-});
+  destination: (req, file, cb) => {
+    cb(null, `${mediaRoot}`)
+  },
+  filename: (req, file, cb) => {
+    const filename = generateUniqueFilename(file.originalname);
+    cb(null, filename)
+  }
+})
 
-export const upload = multer({storage});
+export const upload = multer({storage})
 
-export const deleteFile = (filename) => {
-    return fs.unlink(getPath(filename));
-};
+export const deleteFile = filename => {
+  return fs.unlink(getPath(filename));
+}
 

--- a/server/lib/media-helpers.js
+++ b/server/lib/media-helpers.js
@@ -1,0 +1,27 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import {last} from 'lodash';
+import multer from 'multer';
+
+const mediaRoot = process.env.NODE_ENV === 'production' ? 'dist/client/media' : 'assets/media';
+
+const getPath = (filename) => {
+    return path.resolve(`${mediaRoot}/${filename}`);
+};
+
+const storage = multer.diskStorage({
+    destination: function (req, file, cb) {
+        cb(null, `${mediaRoot}`)
+    },
+    filename: function (req, file, cb) {
+        const ext = last(file.originalname.split('.'));
+        cb(null, `${file.fieldname}.${ext}`)
+    }
+});
+
+export const upload = multer({storage});
+
+export const deleteFile = (filename) => {
+    return fs.unlink(getPath(filename));
+};
+

--- a/server/routes/media.js
+++ b/server/routes/media.js
@@ -1,20 +1,20 @@
 import Router from 'express-promise-router'
-import {upload} from '../lib/media-helpers';
+import {upload} from '../lib/media-helpers'
 
 import mediaController from '../controllers/media'
 
 export default () => {
-  const mediaRouter = Router({mergeParams: true});
+  const mediaRouter = Router({mergeParams: true})
 
   mediaRouter.route('/admin/media/upload')
     .post(upload.fields([
       {name: 'logo', maxCount: 1},
       {name: 'signature', maxCount: 1},
       {name: 'favicon', maxCount: 1}
-    ]), mediaController.upload);
+    ]), mediaController.upload)
 
   mediaRouter.route('/media')
-    .get(mediaController.read);
+    .get(mediaController.read)
 
   return mediaRouter
 }

--- a/server/routes/media.js
+++ b/server/routes/media.js
@@ -1,33 +1,20 @@
 import Router from 'express-promise-router'
-import multer from 'multer'
-import {last} from 'lodash'
+import {upload} from '../lib/media-helpers';
 
 import mediaController from '../controllers/media'
 
-const storage = multer.diskStorage({
-  destination: function (req, file, cb) {
-    const mediaRoot = process.env.NODE_ENV === 'production' ? 'dist/client' : 'assets'
-    cb(null, `${mediaRoot}/media`)
-  },
-  filename: function (req, file, cb) {
-    const ext = last(file.originalname.split('.'))
-    cb(null, `${file.fieldname}.${ext}`)
-  }
-})
-
-const upload = multer({storage})
-
 export default () => {
-  const mediaRouter = Router({mergeParams: true})
+  const mediaRouter = Router({mergeParams: true});
 
   mediaRouter.route('/admin/media/upload')
     .post(upload.fields([
       {name: 'logo', maxCount: 1},
-      {name: 'signature', maxCount: 1}
-    ]), mediaController.upload)
+      {name: 'signature', maxCount: 1},
+      {name: 'favicon', maxCount: 1}
+    ]), mediaController.upload);
 
   mediaRouter.route('/media')
-    .get(mediaController.read)
+    .get(mediaController.read);
 
   return mediaRouter
 }


### PR DESCRIPTION
Moved logic for working with media uploads to server/lib/media-helpers.js
Added deletion of files after upload
Added favicon field to multer upload in server/routes/media.js
fix for [#152](https://github.com/freeCodeCamp/pantry-for-good/issues/152)