### PR TITLE
Set units for distance and corrency on settings

### DIFF
--- a/client/modules/driver/components/driver-assignment/RouteSummary.js
+++ b/client/modules/driver/components/driver-assignment/RouteSummary.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-const RouteSummary = ({route}) => {
+const RouteSummary = ({route, settings}) => {
   const {distance, duration} = route.routes[0].legs.reduce((acc, x) => ({
     distance: acc.distance + x.distance.value,
     duration: acc.duration + x.duration.value
@@ -12,10 +12,14 @@ const RouteSummary = ({route}) => {
   if (hours) hourString = hours === 1 ? `${hours} hour` : `${hours} hours`
   if (minutes) minuteString = `${minutes} minutes`
 
+  let distanceString = ` ${Math.round(distance * 0.00062137)} mi, `
+  if(settings.distanceUnit == 'km') distanceString = ` ${Math.round(distance / 100) / 10} km, `
+  if(settings.distanceUnit == 'mi') distanceString = ` ${Math.round(distance * 0.00062137)} mi, `
+
   return (
     <div>
       {`${route.routes[0].legs.length} stops,`}
-      {` ${Math.round(distance / 100) / 10} km, `}
+      {distanceString}
       {` approx ${hourString} ${minuteString}`}
     </div>
   )

--- a/client/modules/driver/components/driver-assignment/SelectedDriver.js
+++ b/client/modules/driver/components/driver-assignment/SelectedDriver.js
@@ -44,6 +44,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 })
 
 const DriverListDetail = ({
+  settings,////////RONALD
   driver,
   assign,
   clearRoute,
@@ -74,7 +75,7 @@ const DriverListDetail = ({
       </div>
       {route ?
         <div className="text-center" style={{margin: '0 auto'}}>
-          <RouteSummary route={route} />
+          <RouteSummary route={route} settings={settings}/>
           <Button
             bsStyle="primary"
             onClick={clearRoute}

--- a/client/modules/settings/components/General.js
+++ b/client/modules/settings/components/General.js
@@ -56,6 +56,27 @@ const General = () =>
             rows="5"
           />
         </Col>
+        <Col lg={3}>
+          <RFFieldGroup
+            name="distanceUnit"
+            label="Distance Unit"
+            type="select"
+            required
+          >
+          <option value="km">km</option>
+          <option value="mi">mi</option>
+          </RFFieldGroup>
+        </Col>
+        <Clearfix visibleSmBlock visibleMdBlock />
+        <Col lg={3}>
+          <RFFieldGroup
+            name="moneyUnit"
+            label="Money Unit"
+            type="text"
+            required
+          />
+        </Col>
+        <Clearfix visibleSmBlock visibleMdBlock />
       </Row>
     </BoxBody>
   </Box>

--- a/client/modules/settings/components/SettingsForm.js
+++ b/client/modules/settings/components/SettingsForm.js
@@ -69,6 +69,14 @@ function validate(values) {
     errors.supportNumber = 'Support Number is required'
   }
 
+  if (!values.distanceUnit) {
+    errors.distanceUnit = 'Distance Unit is required'
+  }
+
+  if (!values.moneyUnit) {
+    errors.moneyUnit = 'Money Unit is required'
+  }
+
   return errors
 }
 

--- a/server/controllers/settings.js
+++ b/server/controllers/settings.js
@@ -19,7 +19,7 @@ export default {
     Object.assign(settings, {
       googleAuthentication: !!(config.oauth.googleClientID && config.oauth.googleClientSecret)
     })
-
+    
     // Remove unnecessary info before sending off the object to the client
     delete settings.__v
 

--- a/server/lib/seed/seed-data.js
+++ b/server/lib/seed/seed-data.js
@@ -87,7 +87,7 @@ export const getSettingsFields = () => {
     clientIntakeNumber: faker.phone.phoneNumber(),
     supportNumber: faker.phone.phoneNumber(),
     location: {lat, lng},
-    gmapsApiKey: config.gmapsApiKey
+    gmapsApiKey: config.gmapsApiKey,
   }
 }
 

--- a/server/models/settings.js
+++ b/server/models/settings.js
@@ -36,7 +36,18 @@ const SettingsSchema = new Schema({
     type: String,
     trim: true,
     select: false
-  }
+  },
+  distanceUnit: {
+    type: String,
+    trim: true,
+    enum: ['km','mi'],
+    default: 'mi'
+  },
+  moneyUnit: {
+    type: String,
+    trim: true,
+    default: '$'
+  },
 })
 
 export default mongoose.model(modelTypes.SETTINGS, SettingsSchema)


### PR DESCRIPTION
Set units for distance and currency on settings model and use of the units on the route summary section of the application (only for km and mi -miles-)
All changes where tested locally with the running app.
(159) Units (km/mi, $ etc)
closes #159 