### PR TITLE
(153) Saving a client should update all linked fields

### DIFF
--- a/server/controllers/customer.js
+++ b/server/controllers/customer.js
@@ -5,6 +5,8 @@ import {ADMIN_ROLE, clientRoles, volunteerRoles} from '../../common/constants'
 import Customer from '../models/customer'
 import mailer from '../lib/mail/mail-helpers'
 import User from '../models/user'
+import {updateVolunteer} from '../lib/update-linked-fields'
+import {updateDonor} from '../lib/update-linked-fields'
 
 
 export default {
@@ -21,6 +23,8 @@ export default {
     )
 
     const savedCustomer = await customer.save()
+    updateVolunteer(req.body.fields,customer._id)
+    updateDonor(req.body.fields, customer._id)
     res.json(savedCustomer)
 
     // mailer.send(config.mailer.to, 'A new client has applied.', 'create-customer-email')
@@ -47,7 +51,8 @@ export default {
     } else {
       mailer.sendUpdate(newCustomer)
     }
-
+    updateVolunteer(req.body.fields,customer._id)
+    updateDonor(req.body.fields, customer._id)
     res.json(newCustomer)
   },
 

--- a/server/controllers/donor.js
+++ b/server/controllers/donor.js
@@ -4,6 +4,8 @@ import {ForbiddenError, NotFoundError} from '../lib/errors'
 import {ADMIN_ROLE, clientRoles} from '../../common/constants'
 import Donor from '../models/donor'
 import User from '../models/user'
+import {updateCustomer} from '../lib/update-linked-fields'
+import {updateVolunteer} from '../lib/update-linked-fields'
 
 export default {
   /**
@@ -18,7 +20,8 @@ export default {
     const savedDonor = await donor.save()
 
     await User.findOneAndUpdate({_id: donor._id}, {$push: {roles: clientRoles.DONOR}})
-
+    updateCustomer(req.body.fields, donor._id)
+    updateVolunteer(req.body.fields,donor._id)
     res.json(savedDonor)
   },
 
@@ -35,6 +38,8 @@ export default {
   async update(req, res) {
     const donor = extend(req.donor, req.body)
     const savedDonor = await donor.save()
+    updateCustomer(req.body.fields, donor._id)
+    updateVolunteer(req.body.fields,donor._id)
     res.json(savedDonor)
   },
 

--- a/server/lib/update-linked-fields.js
+++ b/server/lib/update-linked-fields.js
@@ -1,0 +1,54 @@
+import Customer from '../models/customer'
+import Volunteer from '../models/volunteer'
+import Donor from '../models/donor'
+
+/**
+* Update Volunteer fields of address
+*/
+export async function updateVolunteer(reqbodyfields, user_id) {
+  //Updating address of the volunteer role if exists
+  const volunteer = await Volunteer.findById(user_id)
+  if(volunteer != undefined && volunteer != null && volunteer != {}){
+    let oldAdrFields = volunteer.fields
+    for(let j = 0; j < oldAdrFields.length; j++){
+      for(let k = 0; k < reqbodyfields.length; k++){
+        if(oldAdrFields[j].meta == reqbodyfields[k].meta) oldAdrFields[j].value = reqbodyfields[k].value
+      }
+    }
+    await Volunteer.findByIdAndUpdate(user_id, {fields: oldAdrFields})
+  }
+}
+
+/**
+* Update Customer fields of address
+*/
+export async function updateCustomer(reqbodyfields, user_id) {
+  //Updating address of the customer role if exists
+  const customer = await Customer.findById(user_id)
+  if(customer != undefined && customer != null && customer != {}){
+    let oldAdrFields = customer.fields
+    for(let j = 0; j < oldAdrFields.length; j++){
+      for(let k = 0; k < reqbodyfields.length; k++){
+        if(oldAdrFields[j].meta == reqbodyfields[k].meta) oldAdrFields[j].value = reqbodyfields[k].value
+      }
+    }
+    await Customer.findByIdAndUpdate(user_id, {fields: oldAdrFields})
+  }
+}
+
+/**
+* Update Donor fields of address
+*/
+export async function updateDonor(reqbodyfields, user_id) {
+  //Updating address of the customer role if exists
+  const donor = await Donor.findById(user_id)
+  if(donor != undefined && donor != null && donor != {}){
+    let oldAdrFields = donor.fields
+    for(let j = 0; j < oldAdrFields.length; j++){
+      for(let k = 0; k < reqbodyfields.length; k++){
+        if(oldAdrFields[j].meta == reqbodyfields[k].meta) oldAdrFields[j].value = reqbodyfields[k].value
+      }
+    }
+    await Donor.findByIdAndUpdate(user_id, {fields: oldAdrFields})
+  }
+}


### PR DESCRIPTION
Automatic update of the address information between customers, donor and volunteers clients type when one of those is updated.
All changes where tested locally with the app running to ensure stability.
closes #153  -Saving a client should update all linked fields-