### PR TITLE
Add automatic session expiration (#22)

### DIFF
--- a/client/modules/customer/components/CustomerEdit.js
+++ b/client/modules/customer/components/CustomerEdit.js
@@ -97,7 +97,7 @@ class CustomerEdit extends Component {
                 initialValues={toForm(customer, questionnaire)}
               />
             }
-            { customer && !loading &&
+            { customer && !loading && customer.status !== "Rejected" &&
               <Box>
                 <BoxHeader heading="Status" />
                 <BoxBody loading={savingCustomers}>

--- a/server/config/env/all.js
+++ b/server/config/env/all.js
@@ -11,6 +11,7 @@ export default {
   host,
   port,
   sessionCollection: 'sessions',
+  sessionIdleTimeout: 3600000,
   mailFrom: `no-reply@${host}`,
   oauth: {
     googleCallbackURL: `${url}/api/auth/google/callback`

--- a/server/config/express.js
+++ b/server/config/express.js
@@ -30,7 +30,9 @@ export default function(io) {
 
   const sharedSession = session({
     saveUninitialized: false,
+    cookie: { maxAge: config.sessionIdleTimeout },
     resave: true,
+    rolling: true,
     secret: config.sessionSecret,
     store: new mongoStore({
       mongooseConnection: mongoose.connection,


### PR DESCRIPTION
* Automatically expire session if idle for an hour. see `server/config/env/all.js:14`.
* Also fixed a bug that allowed user to set themselves as active even if they're rejected. (I was the one who introduced the bug with my last PR.)

Closes #22