### PR TITLE
Fix query that checks if food item exists already and is not deleted

### DIFF
--- a/server/controllers/food.js
+++ b/server/controllers/food.js
@@ -76,8 +76,9 @@ export default {
 
     //Check to see if an item with the same name already exists in a category
     let categoryWithExistingItem = await Food.findOne(
-      { 'items.name': { $regex: `^${item.name}$`, $options: "i" }, 'items.deleted': false },
-      { 'items.$': 1 }).lean()
+      { items: {$elemMatch:{name: {$regex: `^${item.name}$`, $options: "i"}, deleted: false }} },
+      { 'items.$': 1 }
+    ).lean()
 
     if (categoryWithExistingItem) {
       const existingFoodItem = categoryWithExistingItem.items[0]


### PR DESCRIPTION
The query in createItem() is supposed to check for an item with the same name where deleted is false.  Instead it was searching for a food item with the same name and a separate food item where deleted is false.