### PR TITLE
customer controller middleware restricting customer status updates

### DIFF
--- a/common/constants.js
+++ b/common/constants.js
@@ -67,3 +67,10 @@ export const questionnaireIdentifiers = {
   DONOR: 'questionnaire/donors',
   VOLUNTEER: 'questionnaire/volunteers'
 }
+
+export const customerStatus = {
+  ACCEPTED: 'Accepted',
+  REJECTED: 'Rejected',
+  PENDING: 'Pending',
+  INACTIVE: 'Inactive'
+}

--- a/server/controllers/customer.js
+++ b/server/controllers/customer.js
@@ -120,11 +120,8 @@ export default {
     ]
 
     if (req.user && !intersection(req.user.roles, unrestrictedRoles).length) {
-      const customer = extend(req.customer, req.body)
-      const oldCustomer = await Customer.findById(customer._id)
-
-      const statusChanged = oldCustomer.status !== customer.status
-      if (statusChanged && includes(restrictedStatus, oldCustomer.status))
+      const statusChanged = req.customer.status !== req.body.status
+      if (statusChanged && includes(restrictedStatus, req.customer.status))
         throw new ForbiddenError
     }
 

--- a/server/routes/customer.js
+++ b/server/routes/customer.js
@@ -11,8 +11,7 @@ const deleteSchema = {...sync, type: 'customer/DELETE_SUCCESS'}
 
 export default () => {
   const {requiresLogin} = userController
-  const {hasAuthorization} = customerController
-  const {canChangeStatus} = customerController
+  const {hasAuthorization, canChangeStatus} = customerController
 
   const customerRouter = Router({mergeParams: true})
 

--- a/server/routes/customer.js
+++ b/server/routes/customer.js
@@ -12,6 +12,7 @@ const deleteSchema = {...sync, type: 'customer/DELETE_SUCCESS'}
 export default () => {
   const {requiresLogin} = userController
   const {hasAuthorization} = customerController
+  const {canChangeStatus} = customerController
 
   const customerRouter = Router({mergeParams: true})
 
@@ -21,7 +22,7 @@ export default () => {
 
   customerRouter.route('/customer/:customerId')
     .get(requiresLogin, hasAuthorization, customerController.read)
-    .put(requiresLogin, hasAuthorization, customerController.update)
+    .put(requiresLogin, hasAuthorization, canChangeStatus, customerController.update)
 
   customerRouter.route('/admin/customers/:customerId')
     .get(customerController.read)


### PR DESCRIPTION
Customer controller will restrict status changes for non-admins when updating a customer status from Reject or Pending.

Attempting to resolve Issue #227 .