### PR TITLE
(#119-2)New PlaceHolder in common/placeholders

### DIFF
--- a/common/placeholders.js
+++ b/common/placeholders.js
@@ -32,7 +32,14 @@ const placeholders = [
     label: 'Signature',
     type: placeholderTypes.ATTACHMENT,
     format: () => '<img src="cid:signature" alt="Signature" />'
-  }
+  },
+  {
+    id: 'items',
+    label: 'Donation Receipt Information',
+    type: placeholderTypes.EMAIL,
+    required: true,
+    format: value => table(value)
+  },
 ]
 
 function getPagePlaceholders() {
@@ -57,6 +64,16 @@ function getPlaceholders(types) {
     placeholders = placeholders.concat(getAttachmentPlaceholders())
 
   return placeholders
+}
+
+function table(value) {
+  let tableFinal = `<table><tr><td><p>Item</p></td><td><p>Value</p></td></tr>`
+  let total = 0
+  for (let i = 0; i < value.length; i++) {
+    tableFinal += `<tr><td><p>"${value[i].name}"</p></td><td><p>"${value[i].value}"</p></td></tr>`
+    total += value[i].value
+  }
+  return tableFinal + `<tr><td><p>Total:</p></td><td><p>"${total}"</p></td></tr></table>`
 }
 
 export {

--- a/server/lib/mail/mail-helpers.js
+++ b/server/lib/mail/mail-helpers.js
@@ -15,7 +15,6 @@ export default {
   async send(toEmail, toName, identifier, bindings = null) {
     const settings = await Settings.findOne().lean()
     const mail = await mailGenerator(identifier, {...settings, ...bindings})
-
     if (!mail) return
 
     try {
@@ -90,14 +89,14 @@ export default {
   },
 
   async sendReceipt(donation) {
-    const {donor} = donation
+    const {donor, items} = donation
     const {firstName, lastName, email} = donor
     const fullName = `${firstName} ${lastName}`
     await this.send(
       email,
       fullName,
       pageIdentifiers.DONATION_RECEIPT,
-      {firstName, lastName, fullName}
+      {firstName, lastName, fullName, items}
     )
   }
 }

--- a/server/lib/seed/seed-data.js
+++ b/server/lib/seed/seed-data.js
@@ -174,14 +174,16 @@ export const pages = [{
 <p>
   <span class="ql-placeholder-content" data-id="organization" data-label="Foodbank Name"></span> is committed to protecting your personal information by following responsible information handling practices and in keeping with privacy laws. All information remains strictly confidential as outlined by <span class="ql-placeholder-content" data-id="organization" data-label="Foodbank Name"></span>'s Privacy Policy that can be accessed at <span class="ql-placeholder-content" data-id="url" data-label="Foodbank Website"></span>.
 </p>
-<p>If you have any questions or concerns, feel free to contact us.</p>`
+<p>If you have any questions or concerns, feel free to contact us.</p>
+`
 }, {
   identifier: pageIdentifiers.DONATION_RECEIPT,
   title: 'Donation Receipt',
   type: pageTypes.EMAIL,
   subject: '<p>Receipt for Your Donation to <span class="ql-placeholder-content" data-id="organization" data-label="Foodbank Name"></span></p>',
   body: `<p>Dear <span class="ql-placeholder-content" data-id="fullName" data-label="User Full Name"></span>,</p>
-`
+<p>Here you have a list of the donations our organization recibed from you:</p>
+<p><span class="ql-placeholder-content" data-id="items" data-label="Donation Receipt information" data-required="true"></span></p>`
 }]
 
 const commonFields = [


### PR DESCRIPTION
To fix #119 second point:
A new placeholder for the receipt in common/placeholders. It should be required and added to the email during db seeding, like the password reset url placeholder. It should render a table with the donated items and values and total.
A new place holder was created with a table structure to send the donation detail in the receipt.
All changes where tested locally and with the lint command!