### PR TITLE
Fix `admin-lte` version issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "dependencies": {
     "@mapbox/polyline": "^0.2.0",
-    "admin-lte": "^2.3.11",
+    "admin-lte": "~2.3.11",
     "autoprefixer": "^7.1.1",
     "babel-core": "^6.22.1",
     "babel-loader": "^7.1.1",


### PR DESCRIPTION
Force use of `admin-lte` ~2.3, as 2.4.0 is currently breaking the webpack compile.

Addresses #255.