### PR TITLE
Invert orientation of the pagination dropdown menu

### DIFF
--- a/client/modules/core/css/core.css
+++ b/client/modules/core/css/core.css
@@ -40,3 +40,11 @@ li.treeview.active > a > span::after {
 .smallModal > .modal-dialog {
   width: 300px;
 }
+
+/* invert bootstrap table pagination */
+.react-bs-table-pagination ul.dropdown-menu[aria-labelledby="pageDropDown"] {
+  top: unset;
+  bottom: calc(100% + 1rem);
+  background-color: #f4f4f4;
+  border-color: #ccc;
+}

--- a/client/modules/customer/components/CustomerList.js
+++ b/client/modules/customer/components/CustomerList.js
@@ -56,6 +56,13 @@ class CustomerList extends Component {
     })) :
     []
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render() {
     const {loading, loadError} = this.props
 
@@ -74,7 +81,8 @@ class CustomerList extends Component {
                 options={{
                   defaultSortName: "_id",
                   defaultSortOrder: 'desc',
-                  noDataText: loading ? '' : 'No customers found'
+                  noDataText: loading ? '' : 'No customers found',
+                  sizePerPageDropDown: this.renderSizePerPageDropDown
                 }}
                 hover
                 striped

--- a/client/modules/donor/components/DonorList.js
+++ b/client/modules/donor/components/DonorList.js
@@ -78,6 +78,13 @@ class DonorList extends Component {
       </Button>
     </div>
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render() {
     const {loading, loadError, savingDonors, saveDonorsError} = this.props
     return (
@@ -95,7 +102,8 @@ class DonorList extends Component {
                 options={{
                   defaultSortName: "_id",
                   defaultSortOrder: 'desc',
-                  noDataText: loading ? '' : 'No donors found'
+                  noDataText: loading ? '' : 'No donors found',
+                  sizePerPageDropDown: this.renderSizePerPageDropDown
                 }}
                 hover
                 striped

--- a/client/modules/driver/components/DriverList.js
+++ b/client/modules/driver/components/DriverList.js
@@ -44,6 +44,13 @@ class DriverAdmin extends Component {
       </Link>
     </div>
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render() {
     const {drivers, loading, loadError} = this.props
 
@@ -62,7 +69,8 @@ class DriverAdmin extends Component {
                 options={{
                   defaultSortName: "_id",
                   defaultSortOrder: 'desc',
-                  noDataText: loading ? '' : 'No drivers found'
+                  noDataText: loading ? '' : 'No drivers found',
+                  sizePerPageDropDown: this.renderSizePerPageDropDown
                 }}
                 hover
                 striped

--- a/client/modules/food/components/Schedule.js
+++ b/client/modules/food/components/Schedule.js
@@ -66,6 +66,13 @@ class Schedule extends Component {
     return true
   }
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render() {
     const {loading, saving, error} = this.props
 
@@ -81,7 +88,8 @@ class Schedule extends Component {
                 options={{
                   defaultSortName: "name",
                   defaultSortOrder: 'desc',
-                  noDataText: loading ? '' : 'No items found'
+                  noDataText: loading ? '' : 'No items found',
+                  sizePerPageDropDown: this.renderSizePerPageDropDown
                 }}
                 cellEdit={{
                   mode: 'click',

--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -223,6 +223,13 @@ class FoodItems extends React.Component {
     }
   }
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render = () => {
     // set options for react-bootstrap-table
     const tableOptions = {
@@ -230,6 +237,7 @@ class FoodItems extends React.Component {
       toolBar: this.createCustomToolBar,
       defaultSortName: 'name',
       defaultSortOrder: 'asc',
+      sizePerPageDropDown: this.renderSizePerPageDropDown,
       noDataText: (this.props.foodCategories.length === 0)
         ? 'No foods in inventory. Add a category prior to adding a food'
         : 'No foods in inventory matching ' + this.state.searchText,

--- a/client/modules/food/components/packing/Packages.js
+++ b/client/modules/food/components/packing/Packages.js
@@ -35,7 +35,14 @@ class Packages extends Component {
   formatContents = contentList => {
     return contentList.reduce((prev, curr) => {return `${prev} ${curr.name},`}, "")
   }
-  
+
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   getActionButtons = (_, foodPackage) =>
     <div>
       <Button bsStyle="danger"
@@ -55,6 +62,7 @@ class Packages extends Component {
             options={{
               defaultSortName: "datePacked",
               defaultSortOrder: 'desc',
+              sizePerPageDropDown: this.renderSizePerPageDropDown,
               noDataText: loading ? '' : 'No packages'
             }}
             hover

--- a/client/modules/food/components/packing/PackingList.js
+++ b/client/modules/food/components/packing/PackingList.js
@@ -140,6 +140,13 @@ class PackingList extends Component {
     this.props.clearPackingFlags()
   }
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render() {
     const {loading, packSaving, loadError, packSaveError, packedCustomers} = this.props
     const {selected} = this.state
@@ -163,7 +170,8 @@ class PackingList extends Component {
             options={{
               defaultSortName: "_id",
               defaultSortOrder: 'desc',
-              noDataText: loading ? '' : 'Nothing to pack'
+              noDataText: loading ? '' : 'Nothing to pack',
+              sizePerPageDropDown: this.renderSizePerPageDropDown
             }}
             selectRow={{
               mode: 'checkbox',

--- a/client/modules/users/components/UserList.js
+++ b/client/modules/users/components/UserList.js
@@ -36,6 +36,13 @@ class UserList extends Component {
       </Link>
     </div>
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render = () =>
     <Box>
       <BoxHeader heading="User Accounts" />
@@ -49,7 +56,8 @@ class UserList extends Component {
           options={{
             defaultSortName: "_id",
             defaultSortOrder: 'asc',
-            noDataText: this.props.loading ? '' : 'No Accounts Found'
+            noDataText: this.props.loading ? '' : 'No Accounts Found',
+            sizePerPageDropDown: this.renderSizePerPageDropDown
           }}
           hover
           striped

--- a/client/modules/volunteer/components/VolunteerList.js
+++ b/client/modules/volunteer/components/VolunteerList.js
@@ -55,6 +55,13 @@ class VolunteerList extends Component {
     })) :
     []
 
+  renderSizePerPageDropDown = (props) => {
+    return (
+      <SizePerPageDropDown
+        variation='dropup'/>
+    );
+  }
+
   render() {
     const {loading, loadError} = this.props
 
@@ -73,7 +80,8 @@ class VolunteerList extends Component {
                 options={{
                   defaultSortName: "_id",
                   defaultSortOrder: 'desc',
-                  noDataText: loading ? '' : 'No volunteers found'
+                  noDataText: loading ? '' : 'No volunteers found',
+                  sizePerPageDropDown: this.renderSizePerPageDropDown
                 }}
                 hover
                 striped


### PR DESCRIPTION
Instead of showing the dropdown menu orientated to the bottom of the button, invert it and show it above, to prevent the dropdown menu to overflow out of the bottom of the page. This happened to me quite often, when the page wasn't scrolled down completely and the pagination button was just barely visible. When clicking it I was only able to see like the "10" and "20" but often the "30" and "50" were not visible at all.

Not entirely sure this is in the right place, but I couldn't really find any specific styles for this except the default bootstrap styles. Feel free to guide me to the right place.