### PR TITLE
Fix/packing controller check quality

### DIFF
--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -20,7 +20,6 @@ class FoodItems extends React.Component {
       modalInputFields: { name: "", categoryId: "", quantity: "" },
       validInput: false,
       searchText: "",
-      hasBeenChanged: false,
 
       //store initial value
       initialModalInputFields: { name: "", categoryId: "", quantity: "" },
@@ -44,25 +43,20 @@ class FoodItems extends React.Component {
         showModal: 'Add',
         editModalFood: undefined,
         modalInputFields: { name: "", categoryId: "", quantity: "" },
-        hasBeenChanged: false
       })
     } else {
       // Open the modal in 'edit' mode
       const food = this.props.foodItems.find(food => food._id === _id)
+      const inputFields = {
+        name: food.name,
+        categoryId: food.categoryId,
+        quantity: food.quantity.toString()
+      }
       this.setState({
         showModal: 'Edit',
         editModalFood: food,
-        initialModalInputFields: {
-          name: food.name,
-          categoryId: food.categoryId,
-          quantity: food.quantity.toString()
-        },
-        modalInputFields: {
-          name: food.name,
-          categoryId: food.categoryId,
-          quantity: food.quantity
-        },
-        hasBeenChanged: false
+        initialModalInputFields: inputFields,
+        modalInputFields: inputFields,
       })
     }
     this.props.clearFlags()
@@ -75,7 +69,6 @@ class FoodItems extends React.Component {
       editModalFood: undefined,
       modalInputFields: { name: "", categoryId: "", quantity: "" },
       validInput: false,
-      hasBeenChanged: false
     })
     this.props.clearFlags()
   }
@@ -150,15 +143,17 @@ class FoodItems extends React.Component {
    * Re-computes the value for state.validInput
    */
   validate = () => {
-    this.setState({ validInput: this.getValidationState.all() })
+    this.setState({ validInput: this.getValidationState.all() && this.checkChanged() })
   }
 
   /**
    *  check whether newly edited values are different from the inital values
    */
    checkChanged = () => {
-     //console.log(JSON.stringify(this.state.initialModalInputFields), JSON.stringify(this.state.modalInputFields))
-     return JSON.stringify(this.state.initialModalInputFields) === JSON.stringify(this.state.modalInputFields) ? false : true
+     return Object.keys(this.state.modalInputFields).map(key =>
+       this.state.initialModalInputFields[key] !== this.state.modalInputFields[key]
+     ).reduce((acc, x) => acc || x, false)
+
    }
 
   /**
@@ -174,7 +169,6 @@ class FoodItems extends React.Component {
             name: value,
             categoryId: this.state.modalInputFields.categoryId
           },
-          hasBeenChanged: true
         }, this.validate)
       } else if (value !== null) {
         // The user entered an existing food name and autosuggest provided the object for that food
@@ -184,7 +178,6 @@ class FoodItems extends React.Component {
             name: value ? value.name : "",
             categoryId: value ? value.categoryId : ""
           },
-          hasBeenChanged: true
         }, this.validate)
       } else {
         this.setState({
@@ -193,7 +186,6 @@ class FoodItems extends React.Component {
             name: "",
             categoryId: this.state.modalInputFields.categoryId
           },
-          hasBeenChanged: true
         }, this.validate)
       }
     },
@@ -327,9 +319,9 @@ class FoodItems extends React.Component {
               </Modal.Body>
               <Modal.Footer>
                 <Button onClick={this.closeModal}>Cancel</Button>
-                <Button className={this.state.validInput && this.checkChanged() && 'btn-success'}
+                <Button className={this.state.validInput && 'btn-success'}
                   onClick={this.saveFood}
-                  disabled={!this.state.validInput || !this.checkChanged() || this.props.saving}>
+                  disabled={!this.state.validInput || this.props.saving}>
                   {this.state.showModal === 'Add' ? 'Add' : 'Update'}
                 </Button>
               </Modal.Footer>

--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -257,7 +257,7 @@ class FoodItems extends React.Component {
       <div>
         <Box>
           <BoxBody
-
+            // Don't show loading spinner or error message on main page when modal is showing
             loading={this.state.showModal ? undefined : (this.props.loading || this.props.saving)}
             error={this.state.showModal ? undefined : (this.props.loadError || this.props.saveError)}
             errorBottom={true}>

--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -20,7 +20,10 @@ class FoodItems extends React.Component {
       modalInputFields: { name: "", categoryId: "", quantity: "" },
       validInput: false,
       searchText: "",
-      hasBeenChanged: false
+      hasBeenChanged: false,
+
+      //store initial value
+      initialModalInputFields: { name: "", categoryId: "", quantity: "" },
     }
   }
 
@@ -49,6 +52,11 @@ class FoodItems extends React.Component {
       this.setState({
         showModal: 'Edit',
         editModalFood: food,
+        initialModalInputFields: {
+          name: food.name,
+          categoryId: food.categoryId,
+          quantity: food.quantity.toString()
+        },
         modalInputFields: {
           name: food.name,
           categoryId: food.categoryId,
@@ -58,6 +66,7 @@ class FoodItems extends React.Component {
       })
     }
     this.props.clearFlags()
+
   }
 
   closeModal = () => {
@@ -125,11 +134,11 @@ class FoodItems extends React.Component {
   getValidationState = {
     // The following 3 functions validate the individual input fields and return the validation state used for react-bootstrap-table
     foodName: () =>
-      this.state.modalInputFields.name.trim().length || !this.state.hasBeenChanged ? null : 'error',
+      this.state.modalInputFields.name.trim().length ? null : 'error',
     foodQuantity: () =>
-      (this.state.modalInputFields.quantity !== "" && this.state.modalInputFields.quantity >= 0) || !this.state.hasBeenChanged  ? null : 'error',
+      (this.state.modalInputFields.quantity !== "" && this.state.modalInputFields.quantity >= 0) ? null : 'error',
     foodCategory: () =>
-      (this.state.modalInputFields.categoryId !== "") || !this.state.hasBeenChanged  ? null : 'error',
+      (this.state.modalInputFields.categoryId !== "") ? null : 'error',
     // This returns true or false if all fields are valid
     all: () =>
       this.getValidationState.foodName() === null &&
@@ -143,6 +152,14 @@ class FoodItems extends React.Component {
   validate = () => {
     this.setState({ validInput: this.getValidationState.all() })
   }
+
+  /**
+   *  check whether newly edited values are different from the inital values
+   */
+   checkChanged = () => {
+     //console.log(JSON.stringify(this.state.initialModalInputFields), JSON.stringify(this.state.modalInputFields))
+     return JSON.stringify(this.state.initialModalInputFields) === JSON.stringify(this.state.modalInputFields) ? false : true
+   }
 
   /**
    * functions to handle any changes of user input fields in the add/edit modal
@@ -240,7 +257,7 @@ class FoodItems extends React.Component {
       <div>
         <Box>
           <BoxBody
-            // Don't show loading spinner or error message on main page when modal is showing
+
             loading={this.state.showModal ? undefined : (this.props.loading || this.props.saving)}
             error={this.state.showModal ? undefined : (this.props.loadError || this.props.saveError)}
             errorBottom={true}>
@@ -310,9 +327,9 @@ class FoodItems extends React.Component {
               </Modal.Body>
               <Modal.Footer>
                 <Button onClick={this.closeModal}>Cancel</Button>
-                <Button className={this.state.validInput && 'btn-success'}
+                <Button className={this.state.validInput && this.checkChanged() && 'btn-success'}
                   onClick={this.saveFood}
-                  disabled={!this.state.validInput || this.props.saving}>
+                  disabled={!this.state.validInput || !this.checkChanged() || this.props.saving}>
                   {this.state.showModal === 'Add' ? 'Add' : 'Update'}
                 </Button>
               </Modal.Footer>


### PR DESCRIPTION
client/modules/food/components/inventory/FoodItems.js:125 ~138

When `this.state.hasBeenChanged` stays `false` (default), 
this line 
```javascript
(this.state.modalInputFields.quantity !== "" && this.state.modalInputFields.quantity >= 0) || !this.state.hasBeenChanged  ? null : 'error'
```
 allows user to put any quantity value, including negative values. Also, I believe that `this.state.hasBeenChanged` will only become `true` when user changes food name. 

Thus, the approach is to remove parts that checking `this.state.hasBeenChanged`. Instead, we can 
store initial values (name, category, quantity) for each food item when an edit-modal appears. Then, we can decide to disable update button based on comparison between initial values and new inputs.

closes #248 
