### PR TITLE
strict selection of markers when click MarkerCluster

### DIFF
--- a/client/modules/driver/components/driver-assignment/map/Markers.js
+++ b/client/modules/driver/components/driver-assignment/map/Markers.js
@@ -71,7 +71,6 @@ const Markers = ({
           icon={isSelected(customer._id) ? selectedCustomerIcon : customerIcon}
           position={customer.location}
           onClick={toggleCustomer(customer._id)}
-          title={customer._id.toString()}
         />
       )}
     </MarkerClusterer>

--- a/client/modules/driver/components/driver-assignment/map/Markers.js
+++ b/client/modules/driver/components/driver-assignment/map/Markers.js
@@ -71,6 +71,7 @@ const Markers = ({
           icon={isSelected(customer._id) ? selectedCustomerIcon : customerIcon}
           position={customer.location}
           onClick={toggleCustomer(customer._id)}
+          title={customer._id.toString()}
         />
       )}
     </MarkerClusterer>

--- a/client/modules/driver/reducers/assignment.js
+++ b/client/modules/driver/reducers/assignment.js
@@ -1,4 +1,4 @@
-import {difference, get, union, find} from 'lodash'
+import {difference, get, union} from 'lodash'
 import {createSelector} from 'reselect'
 import {normalize} from 'normalizr'
 
@@ -35,18 +35,8 @@ export const toggleCustomer = customerId => ({
 
 export const selectCluster = (cluster, customers, selectedCustomerIds) => {
 
-  const fakeMarkers = customers.map(customer => ({
-    ...customer,
-    lat: customer.location.lat,
-    lng: customer.location.lng,
-  }))
-
-  const markersInCluster = cluster.getMarkers().reduce((acc, curr) => {
-    return acc.concat(find(fakeMarkers,
-      { lat: Number(curr.position.lat().toFixed(6)),
-        lng: Number(curr.position.lng().toFixed(6)) }
-    ))
-  },[])
+  const bound = cluster.getBounds();
+  const markersInCluster = customers.filter(customer => bound.contains(customer.location));
 
   const allMarkersSelected = markersInCluster.reduce((acc, m) =>
     selectedCustomerIds.find(id => id === m._id) ? acc : false

--- a/client/modules/driver/reducers/assignment.js
+++ b/client/modules/driver/reducers/assignment.js
@@ -1,4 +1,4 @@
-import {difference, get, union} from 'lodash'
+import {difference, get, union, find} from 'lodash'
 import {createSelector} from 'reselect'
 import {normalize} from 'normalizr'
 
@@ -34,13 +34,19 @@ export const toggleCustomer = customerId => ({
 })
 
 export const selectCluster = (cluster, customers, selectedCustomerIds) => {
+
   const fakeMarkers = customers.map(customer => ({
     ...customer,
-    getPosition: function() {return customer.location}
+    lat: customer.location.lat,
+    lng: customer.location.lng,
   }))
 
-  const markersInCluster = fakeMarkers.filter(marker =>
-    cluster.isMarkerInClusterBounds(marker))
+  const markersInCluster = cluster.getMarkers().reduce((acc, curr) => {
+    return acc.concat(find(fakeMarkers,
+      { lat: Number(curr.position.lat().toFixed(6)),
+        lng: Number(curr.position.lng().toFixed(6)) }
+    ))
+  },[])
 
   const allMarkersSelected = markersInCluster.reduce((acc, m) =>
     selectedCustomerIds.find(id => id === m._id) ? acc : false

--- a/client/modules/driver/reducers/assignment.spec.js
+++ b/client/modules/driver/reducers/assignment.spec.js
@@ -5,12 +5,9 @@ describe('assignment reducer', function() {
   describe('action creators', function() {
 
     const cluster = {
-      getMarkers(){
-        return [
-          {position: {lat: function(){return 6}, lng: function(){return 6}}},
-          {position: {lat: function(){return 8}, lng: function(){return 8}}}
-        ]
-      },
+      getBounds(){ return { contains: function(position){
+        return inRange(position)
+      } }}
     }
 
     it('selectCluster selects unselected customers', function() {

--- a/client/modules/driver/reducers/assignment.spec.js
+++ b/client/modules/driver/reducers/assignment.spec.js
@@ -3,10 +3,14 @@ import * as reducer from './assignment'
 
 describe('assignment reducer', function() {
   describe('action creators', function() {
+
     const cluster = {
-      isMarkerInClusterBounds(marker) {
-        return inRange(marker.getPosition())
-      }
+      getMarkers(){
+        return [
+          {position: {lat: function(){return 6}, lng: function(){return 6}}},
+          {position: {lat: function(){return 8}, lng: function(){return 8}}}
+        ]
+      },
     }
 
     it('selectCluster selects unselected customers', function() {


### PR DESCRIPTION
- client/modules/driver/reducers/assignment.js

Apparently, MarkerClusterer’s bound is ‘larger’ than it is supposed to. As a result,  `MarkerCluster.isMarkerInClusterBounds()` returns true to those markers located nearby but not inside the cluster.
So, how about we instead use `MarkerClusterer.getMarkers()`, which returns array of the markers assigned to this cluster. Then we can compare their location coordinates (lat,lng) with those of customer markers, and return those match each other. 

My concern is the way the code compares customer makers to markers in each cluster. It looks for matching lat/lng coordinates by ‘assuming’ all customer makers have coordinates with 6 decimal points. (this works just fine with current data set)

- client/modules/driver/reducers/assignment.spec.js 

Above modification requires our mock cluster object to have method getMarkers(). 

Please let me know if have any suggestions!

closes #215 