### PR TITLE
Selecting item from autosuggest now moves focus to quantity

### DIFF
--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -147,6 +147,19 @@ class FoodItems extends React.Component {
   }
 
   /**
+   *  callback for setState when user selects an existing food name from Autosuggest
+   */
+  validateFocus = () => {
+    this.validate
+    this.quantity.focus()
+
+    //moves cursor to end of field on edit
+    let storedValue = this.quantity.value
+    this.quantity.value = ''
+    this.quantity.value = storedValue
+  }
+
+  /**
    *  check whether newly edited values are different from the inital values
    */
    checkChanged = () => {
@@ -178,7 +191,7 @@ class FoodItems extends React.Component {
             name: value ? value.name : "",
             categoryId: value ? value.categoryId : ""
           },
-        }, this.validate)
+        }, this.validateFocus)
       } else {
         this.setState({
           modalInputFields: {
@@ -314,6 +327,7 @@ class FoodItems extends React.Component {
                       value={this.state.modalInputFields.quantity}
                       placeholder="Quantity"
                       onChange={this.handleChange.foodQuantity}
+                      inputRef={ref => {this.quantity = ref}}
                     />
                   </FormGroup>
                   <input type="submit" style={{ position: "absolute", left: "-9999px", width: "1px", height: "1px" }} />


### PR DESCRIPTION
Addresses item in [Food Inventory #171 ](https://github.com/freeCodeCamp/pantry-for-good/issues/171)

Selecting an existing food item from autosuggest now moves focus to quantity.  If editing an existing item, moves cursor to end of line like when editing categories.  

**Added:** 

- inputRef to foodQuantity FormControl
- handChange.foodName now uses callback this.validateFocus
- validateFocus function calls validate like before, focus on quantity.focus, moves cursor