### PR TITLE
fixes #281 shows address as required in general settings

### DIFF
--- a/client/modules/settings/components/General.js
+++ b/client/modules/settings/components/General.js
@@ -82,6 +82,7 @@ const General = () =>
             label="Address"
             type="textarea"
             rows="5"
+            required
           />
         </Col>
       </Row>


### PR DESCRIPTION
Fix for issue #281, now address (under settings/general) has an '*' to show that it is a required field.