### PR TITLE
Fixes broken driver routes list CSS

### DIFF
--- a/client/modules/driver/driver.css
+++ b/client/modules/driver/driver.css
@@ -3,6 +3,7 @@
 }
 
 .assignForm > .box > .box-body {
+	overflow-y: auto;
 	height: calc(100vh - 170px);
 }
 
@@ -22,7 +23,7 @@
 
 /* ugly way to freeze table headers */
 .customerSelector .table-responsive > table > thead {
-	position: absolute;
+	position: static;
 	width: calc(100% - 35px);
 	z-index: 2;
 	background-color: #ffffff;
@@ -41,7 +42,6 @@
 }
 
 .customerSelector .table-responsive > table > tbody {
-	display: block;
 	padding-top: 38px
 }
 


### PR DESCRIPTION
Fixes the driver routes list table that had the addresses going out of the table.
![image](https://user-images.githubusercontent.com/10442924/32267739-8fcb953e-beec-11e7-8698-2f37c0d4db8f.png)

closes #291 