### PR TITLE
Make volunteer schema non-recursive

### DIFF
--- a/common/schemas.js
+++ b/common/schemas.js
@@ -36,11 +36,14 @@ export const arrayOfSections = new schema.Array(section)
 export const arrayOfUsers = new schema.Array(user)
 export const arrayOfVolunteers = new schema.Array(volunteer)
 
+const shallowVolunteer = new schema.Entity('volunteers', {
+  fields: [{meta: field}],
+}, {idAttribute: '_id'})
 customer.define({
   fields: [{meta: field}],
   foodPreferences: arrayOfFoodItems,
   packingList: arrayOfFoodItems,
-  assignedTo: volunteer
+  assignedTo: shallowVolunteer
 })
 
 donation.define({donor})
@@ -63,7 +66,12 @@ foodCategory.define({
   items: arrayOfFoodItems
 })
 
+const shallowCustomer = new schema.Entity('customers', {
+  fields: [{meta: field}],
+  foodPreferences: arrayOfFoodItems,
+  packingList: arrayOfFoodItems,
+}, {idAttribute: '_id'})
 volunteer.define({
   fields: [{meta: field}],
-  customers: arrayOfCustomers
+  customers: new schema.Array(shallowCustomer)
 })


### PR DESCRIPTION
Normalizr doesn't like recursive schemas, and while `denormalize()` will fix this for you, `normalize()` will not.

Problem arose when attempting to update a volunteer with customers. The volunteer object would be normalized in `formatRequestBody()` of _client/store/middleware/api.js_, but volunteer holds references to customers and the customers hold a reference back to the volunteer, which results in a `RangeError` being thrown due to infinite recursion.

Closes #301 