### PR TITLE
add API key to secrets template and node-geocoder

### DIFF
--- a/server/config/env/secrets-template.js
+++ b/server/config/env/secrets-template.js
@@ -1,5 +1,5 @@
 export default {
-  gmapsApiKey: '',
+  gmapsApiKey: process.env.GMAPS_API_KEY || '',
   oauth: {
     googleClientID: process.env.GOOGLE_CLIENT_ID || '',
     googleClientSecret: process.env.GOOGLE_CLIENT_SECRET || '',

--- a/server/lib/geolocate.js
+++ b/server/lib/geolocate.js
@@ -1,3 +1,4 @@
+import keys from '../config/index'
 import nodeGeocoder from 'node-geocoder'
 import {fieldTypes} from '../../common/constants'
 import {getFieldsByType} from '../lib/questionnaire-helpers'
@@ -5,6 +6,7 @@ import {ValidationError} from '../lib/errors'
 
 const geocoder = nodeGeocoder({
   provider: 'google',
+  apiKey: keys.gmapsApiKey,
   formatter: null
 })
 


### PR DESCRIPTION
## the problem

In /server/lib/geolocate.js we use the node-geocoder to geocode addresses — [line 6, here](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/server/lib/geolocate.js#L6). 
However, we do not initialize the geocoder with an API key — [NPM usage example](https://www.npmjs.com/package/node-geocoder)

```javascript
var options = {
  provider: 'google',
  apiKey: 'YOUR_API_KEY', // we do not have this line (!!)
  formatter: null
};
```

After a few requests for address validation (edit an address and click "Update"), Google API throws an OVER_QUERY_LIMIT error:
```
Error: Status is OVER_QUERY_LIMIT. You have exceeded your daily request quota for this API. We recommend registering for a key at the Google Developers Console: https://console.developers.google.com/apis/credentials?project=_
       at /Users/thmsdnnr/dev/Pantry-for-Good/node_modules/node-geocoder/lib/geocoder/googlegeocoder.js:89:25
       at IncomingMessage.<anonymous> (/Users/thmsdnnr/dev/Pantry-for-Good/node_modules/node-geocoder/lib/httpadapter/httpadapter.js:65:9)
       at emitNone (events.js:91:20)
       at IncomingMessage.emit (events.js:185:7)
       at endReadableNT (_stream_readable.js:974:12)
       at _combinedTickCallback (internal/process/next_tick.js:80:11)
       at process._tickCallback (internal/process/next_tick.js:104:9),
  isOperational: true }
```
Errors get thrown in the app too due to trying to JSON parse this response, e.g., [pic](https://user-images.githubusercontent.com/18345212/32608487-23d3b168-c522-11e7-8675-4147dd674553.png).

## proposed solution

* Import the API key from from `/config/index` and pass to the geocoder constructor

* Add a check in the secrets-template for process.env.GMAPS_API_KEY with a fallback to the user-entered key in `secrets-template.js`

closes #310