### PR TITLE
Add missing settings prop to <RouteSummary>

### DIFF
--- a/client/modules/driver/components/driver-assignment/RouteSummary.js
+++ b/client/modules/driver/components/driver-assignment/RouteSummary.js
@@ -1,4 +1,5 @@
 import React from 'react'
+import PropTypes from 'prop-types'
 
 const RouteSummary = ({route, settings}) => {
   const {distance, duration} = route.routes[0].legs.reduce((acc, x) => ({
@@ -23,6 +24,15 @@ const RouteSummary = ({route, settings}) => {
       {` approx ${hourString} ${minuteString}`}
     </div>
   )
+}
+
+RouteSummary.propTypes = {
+  route: PropTypes.shape({
+    routes: PropTypes.array
+  }).isRequired,
+  settings: PropTypes.shape({
+    distanceUnit: PropTypes.oneOf(['km', 'mi'])
+  }).isRequired
 }
 
 export default RouteSummary

--- a/client/modules/driver/components/driver-assignment/SelectedDriver.js
+++ b/client/modules/driver/components/driver-assignment/SelectedDriver.js
@@ -46,6 +46,7 @@ const mergeProps = (stateProps, dispatchProps, ownProps) => ({
 const DriverListDetail = ({
   driver,
   assign,
+  settings,
   clearRoute,
   requestRoute,
   saveRoute,
@@ -75,7 +76,7 @@ const DriverListDetail = ({
     </div>
     {route ?
       <div className="text-center" style={{ margin: '0 auto' }}>
-        <RouteSummary route={route} />
+        <RouteSummary route={route} settings={settings}/>
         <Button
           bsStyle="primary"
           onClick={clearRoute}


### PR DESCRIPTION
Suggest route was not working. This was because the preferred unit of distance was not being passed to the `<RouteSummary>` component via the `settings` prop.

`PropTypes` were defined on `<RouteSummary>` to prevent further problems.

As a side note, this problem was made more difficult to find because the error was being swallowed by [this line](https://github.com/freeCodeCamp/pantry-for-good/blob/9d54d5ebc95d0ba2f7e14251745024920cb93709/client/modules/driver/reducers/route.js#L100). Might want to consider re-throwing unexpected errors in these situations.

Closes #297