### PR TITLE
Enforce type equality in customer list filter function

### DIFF
--- a/client/modules/driver/reducers/assignment.js
+++ b/client/modules/driver/reducers/assignment.js
@@ -141,7 +141,7 @@ export const createSelectors = (path, customerSelectors) => {
         customers.filter(customer => {
           if (!filter) return true
           if (filter === 'unassigned') return !customer.assignedTo
-          return String(get(customer.assignedTo, '_id')) === filter
+          return String(get(customer.assignedTo, '_id')) === String(filter)
         })
     ),
     isCustomerSelected: state => id => createSelector(


### PR DESCRIPTION
## source of the problem

There are two ways that a driver ID can be sent to the code to set the filter. One is by selecting a value from a SELECT dropdown box on the Route Assignment page. Another is to click one of the "Driver Cards" at the top of the page.

The dropdown box sends ev.target.value to dispatch(setFilter()) when it is selected. `ev.target.value ` is of type string, even though its value was set as the Numeric driver._id in the element:

[L22 FilterCustomers.js](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/client/modules/driver/components/driver-assignment/FilterCustomers.js#L22)
`<option key={driver._id} value={driver._id}>`

However, the Driver Cards at the top of the component sets the filter by passing ID directly rather than through an event:

[L12: DriverList.js](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/client/modules/driver/components/driver-assignment/DriverList.js#L12) `setDriver(driver._id)`

In the [assignment reducer](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/client/modules/driver/reducers/assignment.js#L144), we strict-equals compare to filter the customer list to customers assigned to the provided driver ID, `filter`.

`return String(get(customer.assignedTo, '_id')) === filter`

This is fine for the SELECT, because we are comparing type String to type String, so the dropdown works. However, the Driver Cards' IDs are of type numeric, so strict equals compare fails, even though the ID is the "same".

This is why the dropdown works but the Driver Cards do not.

## fixes 
There are ~3 possible fixes:

1) Cast ev.target.value to numeric when it is passed to dispatch(setFilter()) [in L25 of CustomerSelector.js](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/client/modules/driver/components/driver-assignment/CustomerSelector.js#L25) and remove the String() cast on  `get(customer.assignedTo, '_id’)` in the assignment reducer (so we compare numbers with numbers)
2) Loose-equality (==) compare `get(customer.assignedTo, '_id’)` and `filter` in the [assignment reducer](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/client/modules/driver/reducers/assignment.js#L144)
3) Cast both the `get(customer.assignedTo, ‘_id’)` and `filter` to strings and retain the strict equality comparison

I chose number 3.

## reasoning
It's forwards-compatible: if we start to use alphanumeric IDs or decide to use `e.target.value` in another place as a filter key, it will still work. I can’t think of any unexpected behavior that treating the filter ID value as a string could cause. I’m new to this codebase though, so if one of the three (or another one entirely) is better, please let me know!

closes #295