### PR TITLE
null check page.body before passing to react-quill

### DIFF
--- a/client/modules/page/components/PageEditor.js
+++ b/client/modules/page/components/PageEditor.js
@@ -98,7 +98,7 @@ class PageEditor extends React.Component {
 
     return (
       <div className="page-editor">
-        {page &&
+        {page && page.body !== undefined &&
           <div>
             {type === pageTypes.EMAIL &&
               <div>


### PR DESCRIPTION
## the issue
When switching between Page and E-mail editors, we grab the current pages and stash them in state in `PageEditor`. This component's return method passes `page.body` to the ReactQuill component as the value to display in the textarea. However, if `page.body` is undefined, the ReactQuill component doesn't mount properly, giving an error like this:

<img width="327" alt="screen shot 2017-11-10 at 8 18 06 am" src="https://user-images.githubusercontent.com/18345212/32662554-9092d184-c5f0-11e7-9b39-500285c79a29.png">

When you then try to switch between the editor types, the body contents do not display properly, since the ReactQuill component holding the body text did not mount properly. The component receives all the updates (if you console.log out the page.body, the expected body shows up), but since ReactQuill failed to render once, it's "broken" and will not respond to any additional state changes. 

## caused by

The issue is that PageEditor, a child of EditPages, can have a condition where `this.state.page` exists but `this.state.page.body` is undefined. This seems to be due to a delay between fetching the props in the parent and then the way that we send the props to this component from its parent. In [L48-59 of PageEditor.js](https://github.com/freeCodeCamp/pantry-for-good/blob/staging/client/modules/page/components/EditPages.js#L48):

```javascript
  componentWillReceiveProps(nextProps) {
    if (this.props.loading && !nextProps.loading && !nextProps.error)
      this.setState({selectedPage: nextProps.pages[0].identifier})

    if (this.props.saving && !nextProps.saving && !nextProps.error)
      this.setState({dirty: false})

    if (nextProps.type !== this.props.type) {
      nextProps.loadPages()
      this.setState({selectedPage: null})
    }
  }
```
`props.type` holds the page type, one of `email` or `page`. When the page type changes (by clicking on the sidebar link), nextProps.type differs from `this.props.type`, so the third condition happens. PageEditor gets a `selectedPage` set to null, so it updates its state, since its `componentWillReceiveProps` looks like this:
```javascript
  componentWillReceiveProps(nextProps) {
    const {page, selectedPage} = nextProps

    if (selectedPage !== this.props.selectedPage) {
      this.setState({page: {...page}})
    }
  }
```
However, this new page has a page.body of `undefined`, presumably since `loadPages()` is still happening. If you console log a "1" "2" and "3" in each of the 3 conditions of PageEditor's `componentWillReceiveProps`, you get "1" the first time the page loads, and in between switching tabs on a given page, and then when you switch in between pages, you get a "3" and then a "1".

It's in this state between "3" and "1" where `page` exists and yet `page.body` is undefined and ReactQuill fails to mount.

## my solution
I experimented with a few approaches that alter the way `componentWillReceiveProps` works in the parent and child component. This got messy and I was worried I'd break something else in the process. Also, I felt like it'd be best not to couple the components too much in this way, since if we break them out into separate components down the road, it'd make that even messier.

I found the most effective solution to be simply to check for `page.body` being defined in the `return` of the `PageEditor`, and only mounting ReactQuill when we have a `value` to pass.

closes #292