### PR TITLE
Log unexpected errors from `requestGoogleRoute()`

### DIFF
--- a/client/modules/driver/reducers/helpers.js
+++ b/client/modules/driver/reducers/helpers.js
@@ -2,34 +2,35 @@ import {first, last} from 'lodash'
 import polyline from '@mapbox/polyline'
 
 const osrmUrl = 'https://router.project-osrm.org'
+const GOOGLE_ERROR_MAP = {
+  MAX_WAYPOINTS_EXCEEDED: 'Cannot find route for this many stops.',
+  OVER_QUERY_LIMIT: 'You have made too many requests for the current time period.'
+}
+const DEFAULT_GOOGLE_ERROR = 'There was an error calculating the route.'
 
 export const getGoogleRoute = (waypoints, optimize) => {
   const formattedWaypoints = waypoints.map(point => ({
     location: {lat: point.lat, lng: point.lng}
   }))
 
-  let resolve, reject
-  const result = new Promise((res, rej) => {
-    resolve = res
-    reject = rej
+  return new Promise((resolve, reject) => {
+    const directionsService = new google.maps.DirectionsService
+    directionsService.route({
+      origin: first(formattedWaypoints),
+      destination: last(formattedWaypoints),
+      waypoints: formattedWaypoints.slice(1, -1),
+      optimizeWaypoints: optimize,
+      travelMode: google.maps.TravelMode.DRIVING
+    }, (result, status) => {
+      if (status === google.maps.DirectionsStatus.OK) {
+        resolve(result)
+      } else {
+        const error = new Error(GOOGLE_ERROR_MAP[status] || DEFAULT_GOOGLE_ERROR)
+        error.isDirectionsError = true
+        reject(error)
+      }
+    })
   })
-
-  const directionsService = new google.maps.DirectionsService
-  directionsService.route({
-    origin: first(formattedWaypoints),
-    destination: last(formattedWaypoints),
-    waypoints: formattedWaypoints.slice(1, -1),
-    optimizeWaypoints: optimize,
-    travelMode: google.maps.TravelMode.DRIVING
-  }, (result, status) => {
-    if (status === google.maps.DirectionsStatus.OK) {
-      resolve(result)
-    } else {
-      reject(result)
-    }
-  })
-
-  return result
 }
 
 export const getOsrmRoute = (waypoints, optimize) => {

--- a/client/modules/driver/reducers/helpers.js
+++ b/client/modules/driver/reducers/helpers.js
@@ -14,25 +14,21 @@ export const getGoogleRoute = (waypoints, optimize) => {
     reject = rej
   })
 
-  let directionsService
-  try {
-    directionsService = new google.maps.DirectionsService
-    directionsService.route({
-      origin: first(formattedWaypoints),
-      destination: last(formattedWaypoints),
-      waypoints: formattedWaypoints.slice(1, -1),
-      optimizeWaypoints: optimize,
-      travelMode: google.maps.TravelMode.DRIVING
-    }, (result, status) => {
-      if (status === google.maps.DirectionsStatus.OK) {
-        resolve(result)
-      } else {
-        reject(result)
-      }
-    })
-  } catch (err) {
-    reject('Direction service failure')
-  }
+  const directionsService = new google.maps.DirectionsService
+  directionsService.route({
+    origin: first(formattedWaypoints),
+    destination: last(formattedWaypoints),
+    waypoints: formattedWaypoints.slice(1, -1),
+    optimizeWaypoints: optimize,
+    travelMode: google.maps.TravelMode.DRIVING
+  }, (result, status) => {
+    if (status === google.maps.DirectionsStatus.OK) {
+      resolve(result)
+    } else {
+      reject(result)
+    }
+  })
+
   return result
 }
 

--- a/client/modules/driver/reducers/route.js
+++ b/client/modules/driver/reducers/route.js
@@ -97,7 +97,14 @@ export const requestGoogleRoute = (waypoints, optimize) => dispatch => {
 
       dispatch(setWaypoints(optimizedWaypoints))
     })
-    .catch(err => dispatch(routeFailure(err)))
+    .catch(err => {
+      if (err.isDirectionsError) {
+        dispatch(routeFailure(err.message))
+      } else {
+        console.error(err)
+        dispatch(routeFailure('There was an error processing your request.'))
+      }
+    })
 }
 
 export const requestCrudeRoute = waypoints => dispatch => {


### PR DESCRIPTION
`requestGoogleRoute()` currently swallows all errors. Better define expected errors rejected from `getGoogleRoute()` so all others can be rethrown.

Also removed an unnecessary try catch block from `getGoogleRoute()`.