### PR TITLE
Improve food related authorization

### DIFF
--- a/client/Router.js
+++ b/client/Router.js
@@ -2,7 +2,7 @@ import React from 'react'
 import {ConnectedRouter} from 'react-router-redux'
 import {Route} from 'react-router-dom'
 
-import {ADMIN_ROLE, clientRoles} from '../common/constants'
+import {ADMIN_ROLE, volunteerRoles} from '../common/constants'
 
 import Sidebar from './modules/core/components/sidebar/Sidebar'
 import Header from './modules/core/components/Header'
@@ -25,7 +25,9 @@ import requireRole from './components/router/requireRole'
 import SwitchWithNotFound from './components/router/SwitchWithNotFound'
 
 const IsAdmin = requireRole([ADMIN_ROLE])
-const IsVolunteer = requireRole([ADMIN_ROLE, clientRoles.VOLUNTEER])
+const canInventory = requireRole([ADMIN_ROLE, volunteerRoles.INVENTORY])
+const canPack = requireRole([ADMIN_ROLE, volunteerRoles.PACKING])
+const canSchedule = requireRole([ADMIN_ROLE, volunteerRoles.SCHEDULE])
 
 const Router = ({history}) =>
   <ConnectedRouter history={history}>
@@ -40,9 +42,9 @@ const Router = ({history}) =>
           <Route path="/customers" component={Customers} />
           <Route path="/donors" component={Donors} />
           <Route path="/drivers" component={Drivers} />
-          <Route path="/inventory" exact component={IsVolunteer(Inventory)} />
-          <Route path="/packing" exact component={IsVolunteer(Packing)} />
-          <Route path="/schedule" exact component={IsVolunteer(Schedule)} />
+          <Route path="/inventory" exact component={canInventory(Inventory)} />
+          <Route path="/packing" exact component={canPack(Packing)} />
+          <Route path="/schedule" exact component={canSchedule(Schedule)} />
           <Route path="/settings" component={IsAdmin(Settings)} />
           <Route path="/users" component={Users} />
           <Route path="/volunteers" component={Volunteers} />

--- a/server/routes/food.js
+++ b/server/routes/food.js
@@ -20,17 +20,18 @@ export default () => {
 
   const foodRouter = Router({mergeParams: true})
 
+  foodRouter.use('/foods', requiresLogin)
   foodRouter.route('/foods')
-    .get(requiresLogin, foodController.list)
-    .post(foodController.hasAuthorization, websocketMiddleware(saveCatSchema), foodController.create)
+    .get(foodController.list)
+    .post(websocketMiddleware(saveCatSchema), foodController.create)
   foodRouter.route('/foods/:foodId')
-    .put(foodController.hasAuthorization, websocketMiddleware(saveCatSchema), foodController.update)
-    .delete(foodController.hasAuthorization, websocketMiddleware(deleteCatSchema), foodController.delete)
+    .put(websocketMiddleware(saveCatSchema), foodController.update)
+    .delete(websocketMiddleware(deleteCatSchema), foodController.delete)
   foodRouter.route('/foods/:foodId/items')
-    .post(foodController.hasAuthorization, websocketMiddleware(saveItemSchema), foodController.createItem)
+    .post(websocketMiddleware(saveItemSchema), foodController.createItem)
   foodRouter.route('/foods/:foodId/items/:itemId')
-    .put(foodController.hasAuthorization, websocketMiddleware(saveItemSchema), foodController.updateItem)
-    .delete(foodController.hasAuthorization, websocketMiddleware(deleteItemSchema), foodController.deleteItem)
+    .put(websocketMiddleware(saveItemSchema), foodController.updateItem)
+    .delete(websocketMiddleware(deleteItemSchema), foodController.deleteItem)
 
   // Finish by binding the food middleware
   foodRouter.param('foodId', foodController.foodById)


### PR DESCRIPTION
The INVENTORY and SCHEDULE roles were not being properly enforced, allowing any volunteer to perform related tasks.

* Restrict access to /inventory and /schedule based on role.

* Add more granular permissions to the food controller.

* Explicitly require authenticated user for all food endpoints.

I am not all that familiar yet with the code base, so the permissions I set up are likely not correct. But I did try to follow @jspaine's initial suggestions.

Closes #303 