### PR TITLE
Add istanbul test coverage

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -9,7 +9,7 @@
   ],
   "env": {
     "test": {
-      "plugins": ["babel-plugin-rewire"]
+      "plugins": ["istanbul", "babel-plugin-rewire"]
     }
   }
 }

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ node_modules/
 typings/
 server/config/env/secrets.js
 dist
+.nyc_output/
+coverage/

--- a/.nycrc
+++ b/.nycrc
@@ -1,0 +1,28 @@
+  {
+    "reporter": [
+      "lcov"
+    ],
+    "require": [
+      "babel-core/register",
+      "ignore-styles",
+      "./client/entry.test.js",
+      "./server/entry.test.js"
+    ],
+    "sourceMap": false,
+    "instrument": false,
+    "include": [
+      "client/**/*.js",
+      "server/**/*.js"
+    ],
+    "all": true,
+    "exclude": [
+      "**/*.spec.js",
+      "node_modules",
+      "flow-typed",
+      "client/entry.test.js",
+      "server/entry.test.js",
+      "server/index.js",
+      "server/config/env",
+      "server/tests"
+    ]
+  }

--- a/client/.babelrc
+++ b/client/.babelrc
@@ -2,7 +2,7 @@
   "presets": ["es2015", "stage-0", "react"],
   "env": {
     "test": {
-      "plugins": ["babel-plugin-rewire"]
+      "plugins": ["istanbul", "babel-plugin-rewire"]
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "build:server": "gulp build-server",
     "build:client": "gulp build-client",
     "clean": "shx rm -rf dist",
+    "coverage": "cross-env NODE_ENV=test nyc mocha \"./{,!(node_modules)/**/}*.spec.js\"",
     "start": "node dist/server/server.js",
     "lint": "npm run lint:server && npm run lint:client",
     "lint:server": "eslint server",
@@ -128,6 +129,7 @@
   },
   "devDependencies": {
     "babel-eslint": "^7.2.1",
+    "babel-plugin-istanbul": "^4.1.5",
     "babel-plugin-rewire": "^1.0.0",
     "babel-preset-flow": "^6.23.0",
     "babel-register": "^6.24.0",
@@ -143,6 +145,7 @@
     "ignore-styles": "^5.0.1",
     "jsdom": "^11.1.0",
     "mocha": "^3.2.0",
+    "nyc": "^11.3.0",
     "react-test-renderer": "^15.5.4",
     "sinon": "^2.0.0",
     "sinon-chai": "^2.8.0",


### PR DESCRIPTION
With these changes `npm run coverage` will generate a test coverage report in `coverage/lcov-report/index.html`

The one thing I don't like is that I think the babel-plugin-istanbul plugin also gets used with `npm test` when you want to run just the tests without creating a coverage report.  From what I understand, istanbul adds extra code to every statement to keep track of what statements run.  I don't like the idea of all that unnecessary code being put into regular test runs.  

If you have any ideas on how to resolve this or if this shouldn't be a concern please let me know.