### PR TITLE
fixes #243 - validates that donation is NaN on server

### DIFF
--- a/server/controllers/donation.js
+++ b/server/controllers/donation.js
@@ -2,6 +2,7 @@ import {ADMIN_ROLE} from '../../common/constants'
 import Donation from '../models/donation'
 import Donor from '../models/donor'
 import {UnauthorizedError} from '../lib/errors'
+import {BadRequestError} from '../lib/errors'
 import mailer from '../lib/mail/mail-helpers'
 
 export default {
@@ -9,7 +10,13 @@ export default {
 
     let newDonation = {
       ...req.body,
-      total: req.body.items.reduce((acc, item) => acc + Number(item.value), 0)
+      total: req.body.items.reduce((acc, item) => {
+        if (isNaN(Number(item.value))) {
+          throw new BadRequestError
+        } else {
+          return acc + Number(item.value)
+        }
+      },0 )
     }
 
     if (!req.user.roles.find(r => r === ADMIN_ROLE) &&


### PR DESCRIPTION
Checks that donation value is NaN on the server, and throws a BadRequestError if so.