### PR TITLE
Logout on expired sessions

### DIFF
--- a/client/Application.js
+++ b/client/Application.js
@@ -42,15 +42,21 @@ class Application extends Component {
   }
 
   componentDidUpdate() {
-    const {user} = this.props
     window.dispatchEvent(new Event('resize'))
-    if (user && user.roles.find(r => r === ADMIN_ROLE)) {
-      $('body').removeClass('layout-top-nav')
-    }
   }
 
   render() {
-    if (this.state.loaded) return <Router history={this.props.history} />
+    if (this.state.loaded) {
+      const {user} = this.props
+      const isAdmin = user && user.roles.find(r => r === ADMIN_ROLE)
+      return (
+        <div className={`skin-blue fixed ${!isAdmin && 'layout-top-nav'}`}>
+          <div className='wrapper'>
+            <Router history={this.props.history} />
+          </div>
+        </div>
+      )
+    }
 
     if (this.props.error) {
       return <ServerError />

--- a/client/components/router/guestOrRedirect.js
+++ b/client/components/router/guestOrRedirect.js
@@ -1,0 +1,42 @@
+import React from 'react'
+import {connect} from 'react-redux'
+import {push} from 'react-router-redux'
+
+import selectors from '../../store/selectors'
+import userClientRole from '../../lib/user-client-role'
+
+const mapStateToProps = state => ({
+  user: selectors.auth.getUser(state)
+})
+
+const mapDispatchToProps = dispatch => ({
+  push: location => dispatch(push(location))
+})
+
+const redirectIfAlreadySignedIn = props => {
+  if (props.user && props.user._id) {
+    const role = userClientRole(props.user)
+    props.push(role ? `/${role.split('/')[1]}s` : '/')
+  }
+}
+
+const guestOrRedirect = WrappedComponent => {
+  class GuestOrRedirect extends React.Component {
+    constructor(props) {
+      super(props)
+      redirectIfAlreadySignedIn(props)
+    }
+  
+    componentWillReceiveProps(nextProps) {
+      redirectIfAlreadySignedIn(nextProps)
+    }
+  
+    render() {
+      return <WrappedComponent {...this.props} />
+    }
+  }
+
+  return connect(mapStateToProps, mapDispatchToProps)(GuestOrRedirect)
+}
+
+export default guestOrRedirect

--- a/client/index.html
+++ b/client/index.html
@@ -17,7 +17,7 @@
 		<script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
 	<![endif]-->
 </head>
-<body class="skin-blue fixed layout-top-nav">
-  <div id="app" class="wrapper"></div>
+<body>
+  <div id="app"></div>
 </body>
 </html>

--- a/client/modules/users/UserRouter.js
+++ b/client/modules/users/UserRouter.js
@@ -8,6 +8,7 @@ import ConfirmNewGoogleAccount from './components/ConfirmNewGoogleAccount'
 import EditProfile from './components/EditProfile'
 import EditUser from './components/EditUser'
 import ForgotPassword from './components/ForgotPassword'
+import guestOrRedirect from '../../components/router/guestOrRedirect'
 import ResetPassword from './components/ResetPassword'
 import SignIn from './components/SignIn'
 import SignUp from './components/SignUp'
@@ -44,15 +45,15 @@ const UserRouter = ({match}) =>
     <Route
       path={`${match.url}/forgot-password`}
       exact
-      component={ForgotPassword}
+      component={guestOrRedirect(ForgotPassword)}
     />
     <Route
       path={`${match.url}/reset-password/:token`}
       exact
       component={ResetPassword}
     />
-    <Route path={`${match.url}/signin`} exact component={SignIn} />
-    <Route path={`${match.url}/signup`} exact component={SignUp} />
+    <Route path={`${match.url}/signin`} exact component={guestOrRedirect(SignIn)} />
+    <Route path={`${match.url}/signup`} exact component={guestOrRedirect(SignUp)} />
     <Route
       path={`${match.url}/confirm-new-google-account`}
       exact

--- a/client/modules/users/components/ForgotPassword.js
+++ b/client/modules/users/components/ForgotPassword.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import {connect} from 'react-redux'
-import {push} from 'react-router-redux'
 import {Col, Row} from 'react-bootstrap'
 
 import selectors from '../../../store/selectors'
@@ -12,7 +11,6 @@ import LoadingWrapper from '../../../components/LoadingWrapper'
 class ForgotPassword extends React.Component {
   constructor(props) {
     super(props)
-    this.redirectIfAlreadySignedIn(this.props)
     this.state = {
       email: ""
     }
@@ -20,10 +18,6 @@ class ForgotPassword extends React.Component {
 
   componentWillMount() {
     this.props.clearFlags()
-  }
-
-  componentWillReceiveProps = nextProps => {
-    this.redirectIfAlreadySignedIn(nextProps)
   }
 
   onFieldChange = e => {
@@ -34,12 +28,6 @@ class ForgotPassword extends React.Component {
   onSubmit = e => {
     e.preventDefault()
     this.props.resetPassword(this.state.email)
-  }
-
-  redirectIfAlreadySignedIn(props) {
-    if (props.user && props.user._id) {
-      props.push('/')
-    }
   }
 
   render = () => {
@@ -91,7 +79,6 @@ class ForgotPassword extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  user: selectors.auth.getUser(state),
   fetching: selectors.auth.fetching(state),
   error: selectors.auth.error(state),
   success: selectors.auth.success(state)
@@ -99,8 +86,7 @@ const mapStateToProps = state => ({
 
 const mapDispatchToProps = dispatch => ({
   resetPassword: email => dispatch(forgotPassword({ email })),
-  clearFlags: () => dispatch(clearFlags()),
-  push: location => dispatch(push(location))
+  clearFlags: () => dispatch(clearFlags())
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(ForgotPassword)

--- a/client/modules/users/components/SignIn.js
+++ b/client/modules/users/components/SignIn.js
@@ -1,11 +1,9 @@
 import React from 'react'
 import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
-import {push} from 'react-router-redux'
 
 import selectors from '../../../store/selectors'
 import {signIn, clearFlags} from '../authReducer'
-import userClientRole from '../../../lib/user-client-role'
 
 import FieldGroup from '../../../components/form/FieldGroup'
 import {LoginBox} from '../../../components/login'
@@ -13,7 +11,6 @@ import {LoginBox} from '../../../components/login'
 export class SignIn extends React.Component {
   constructor(props) {
     super(props)
-    this.redirectIfAlreadySignedIn(this.props)
     this.state = {
       email: "",
       password: ""
@@ -22,13 +19,6 @@ export class SignIn extends React.Component {
 
   componentWillMount() {
     this.props.clearFlags()
-  }
-
-  redirectIfAlreadySignedIn(props) {
-    if (props.user && props.user._id) {
-      const role = userClientRole(props.user)
-      props.push(role ? `/${role.split('/')[1]}s` : '/')
-    }
   }
 
   onFieldChange = e => {
@@ -40,10 +30,6 @@ export class SignIn extends React.Component {
     e.preventDefault()
     this.props.signIn(this.state.email, this.state.password)
     this.setState({password: ""})
-  }
-
-  componentWillReceiveProps = nextProps => {
-    this.redirectIfAlreadySignedIn(nextProps)
   }
 
   render = () =>
@@ -95,7 +81,6 @@ export class SignIn extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  user: selectors.auth.getUser(state),
   fetchingUser: selectors.auth.fetching(state),
   fetchUserError: selectors.auth.error(state),
   googleAuthentication: (state.settings && state.settings.data) ? state.settings.data.googleAuthentication : false
@@ -105,8 +90,7 @@ const mapDispatchToProps = dispatch => ({
   signIn: (email, password) => {
     dispatch(signIn({ email, password }))
   },
-  clearFlags: () => dispatch(clearFlags()),
-  push: location => dispatch(push(location))
+  clearFlags: () => dispatch(clearFlags())
 })
 
 export default connect(mapStateToProps, mapDispatchToProps)(SignIn)

--- a/client/modules/users/components/SignIn.spec.js
+++ b/client/modules/users/components/SignIn.spec.js
@@ -2,8 +2,6 @@
 import React from 'react'
 import { shallow } from 'enzyme'
 
-import { push as reactRouterReduxPush } from 'react-router-redux'
-
 import ConnectedSignIn, { SignIn } from './SignIn'
 import { signIn as authReducerSignIn, clearFlags as authReducerClearFlags } from '../authReducer'
 
@@ -55,18 +53,6 @@ describe('SignIn Class', function () {
     expect(wrapper.state().email).to.eql('user@example.com')
     expect(wrapper.state().password).to.eql('12345678')
   })
-
-  it('calls props.push if a user is signed in', () => {
-    const spy = sinon.spy()
-    shallow(<SignIn user={{_id: 1}} push={spy} clearFlags={ () => {} } />)
-    expect(spy.called).to.eql(true)
-  })
-
-  it('does not call props.push if a user is not signed in', () => {
-    const spy = sinon.spy()
-    shallow(<SignIn user={null} push={spy} clearFlags={ () => {} } />)
-    expect(spy.called).to.eql(false)
-  })
 })
 
 describe('Connect(SignIn)', function () {
@@ -94,11 +80,6 @@ describe('Connect(SignIn)', function () {
 
   })
 
-  it('gets the user from the redux store', () => {
-    const wrapper = shallow(<ConnectedSignIn />, {context: {store: mockStore}})
-    expect(wrapper.props().user).to.eql(reduxState.auth.user)
-  })
-
   it ('gets the login error from the redux store', () => {
     const wrapper = shallow(<ConnectedSignIn />, {context: {store: mockStore}})
     expect(wrapper.props().fetchUserError).to.eql(mockStore.getState().auth.error)
@@ -119,14 +100,6 @@ describe('Connect(SignIn)', function () {
     wrapper.props().signIn('e', 'p')
     const actualDispatchedAction = mockStore.dispatch.args[0][0]
     const expectedDispatchedAction = authReducerSignIn({email: 'e', password: 'p'})
-    expect(actualDispatchedAction).to.eql(expectedDispatchedAction)
-  })
-
-  it ('dispatches the push action', () => {
-    const wrapper = shallow(<ConnectedSignIn />, {context: {store: mockStore}})
-    wrapper.props().push('/newLocation')
-    const actualDispatchedAction = mockStore.dispatch.args[0][0]
-    const expectedDispatchedAction = reactRouterReduxPush('/newLocation')
     expect(actualDispatchedAction).to.eql(expectedDispatchedAction)
   })
 

--- a/client/modules/users/components/SignUp.js
+++ b/client/modules/users/components/SignUp.js
@@ -1,12 +1,10 @@
 import React from 'react'
-import {get, has, last} from 'lodash'
+import {get, has} from 'lodash'
 import {connect} from 'react-redux'
 import {Link} from 'react-router-dom'
-import {push} from 'react-router-redux'
 
 import selectors from '../../../store/selectors'
 import {signUp, clearFlags} from '../authReducer'
-import userClientRole from '../../../lib/user-client-role'
 import {showDialog, hideDialog} from '../../core/reducers/dialog'
 
 import FieldGroup from '../../../components/form/FieldGroup'
@@ -17,7 +15,6 @@ import './signup.css'
 class SignUp extends React.Component {
   constructor(props) {
     super(props)
-    this.redirectIfAlreadySignedIn(this.props)
     this.state = {
       firstName: {value: '', touched: false},
       lastName: {value: '', touched: false},
@@ -29,13 +26,6 @@ class SignUp extends React.Component {
 
   componentWillMount() {
     this.props.clearFlags()
-  }
-
-  redirectIfAlreadySignedIn(props) {
-    if (props.user && props.user._id) {
-      const role = userClientRole(props.user)
-      props.push(role ? `/${last(role.split('/'))}s` : '/')
-    }
   }
 
   onFieldChange = e => {
@@ -61,10 +51,6 @@ class SignUp extends React.Component {
 
   googleSignup = () => {
     window.location = `/api/auth/google?action=signup`
-  }
-
-  componentWillReceiveProps = nextProps => {
-    this.redirectIfAlreadySignedIn(nextProps)
   }
 
   isValid = field => has(
@@ -166,7 +152,6 @@ class SignUp extends React.Component {
 }
 
 const mapStateToProps = state => ({
-  user: selectors.auth.getUser(state),
   fetchingUser: selectors.auth.fetching(state),
   fetchUserError: selectors.auth.error(state),
   googleAuthentication: get(selectors.settings.getSettings(state), 'googleAuthentication')
@@ -175,7 +160,6 @@ const mapStateToProps = state => ({
 const mapDispatchToProps = dispatch => ({
   signUp: user => dispatch(signUp(user)),
   clearFlags: () => dispatch(clearFlags()),
-  push: location => dispatch(push(location)),
   showDialog: dialogOptions => dispatch(showDialog(dialogOptions)),
   hideDialog: () => dispatch(hideDialog())
 })

--- a/client/store/middleware/api.js
+++ b/client/store/middleware/api.js
@@ -3,6 +3,8 @@ import fetch from 'isomorphic-fetch'
 import {normalize} from 'normalizr'
 import {SubmissionError} from 'redux-form'
 
+import {clearUser} from '../../modules/users/authReducer'
+
 let _socket
 
 const API_ROOT = process.env.NODE_ENV === 'production' ?
@@ -35,7 +37,7 @@ export function callApi(endpoint, method = 'GET', body, schema, responseSchema) 
   })
     .then(response =>
       response.json().then(json => {
-        if (!response.ok) return Promise.reject(json)
+        if (!response.ok) return Promise.reject({ ...json, status: response.status })
         if (responseSchema) return normalize(json, responseSchema)
         if (schema) return normalize(json, schema)
         return json
@@ -93,6 +95,7 @@ export default socket => {
         response
       })),
       error => {
+        if (error.status === 401) store.dispatch(clearUser())
         next(actionWith({
           type: failureType,
           error

--- a/client/store/middleware/api.spec.js
+++ b/client/store/middleware/api.spec.js
@@ -55,7 +55,7 @@ describe('api middleware', function() {
       expect(fetchMock).to.calledWith('root/foo')
 
       return result.catch(err => {
-        expect(err).to.eql({error: 'error'})
+        expect(err).to.include({error: 'error'})
         expect(responseMock.json).to.have.been.calledOnce
       })
     })

--- a/server/routes/donation.js
+++ b/server/routes/donation.js
@@ -1,5 +1,8 @@
 import Router from 'express-promise-router'
 import donationController from '../controllers/donation'
+import usersController from '../controllers/users'
+
+const {requiresLogin} = usersController 
 
 const donationRouter = Router({mergeParams: true})
 
@@ -10,6 +13,6 @@ donationRouter.route('/admin/donations/:donationId/approve')
   .put(donationController.approve)
 
 donationRouter.route('/donations/:donationId')
-  .put(donationController.hasAuthorization, donationController.sendEmail)
+  .put(requiresLogin, donationController.hasAuthorization, donationController.sendEmail)
 
 export default donationRouter

--- a/server/routes/packing.js
+++ b/server/routes/packing.js
@@ -3,6 +3,9 @@ import Router from 'express-promise-router'
 import packingController from '../controllers/packing'
 import websocketMiddleware from '../lib/websocket-middleware'
 import {arrayOfPackages} from '../../common/schemas'
+import usersController from '../controllers/users'
+
+const {requiresLogin} = usersController
 
 const packingRouter = Router({mergeParams: true})
 
@@ -15,6 +18,7 @@ const sync = {
 }
 
 packingRouter.route('/packing')
+  .all(requiresLogin)
   .get(packingController.hasAuthorization, packingController.list)
   .post(packingController.hasAuthorization, websocketMiddleware(sync), packingController.pack)
   .delete(packingController.hasAuthorization, packingController.unpack)

--- a/server/routes/questionnaire.js
+++ b/server/routes/questionnaire.js
@@ -1,9 +1,14 @@
 import Router from 'express-promise-router'
 
 import questionnaireController from '../controllers/questionnaire'
+import usersController from '../controllers/users'
+
+const {requiresLogin} = usersController
 
 export default () => {
   const  questionnaireRouter = Router({mergeParams: true})
+
+  questionnaireRouter.use('/questionnaires', requiresLogin)
 
   questionnaireRouter.route('/questionnaires')
     .get(questionnaireController.query)

--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -1,11 +1,15 @@
 import Router from 'express-promise-router'
 
+import usersController from '../controllers/users'
 import settingsController  from '../controllers/settings'
+
+const {requiresLogin} = usersController
 
 export default () => {
   const settingsRouter = Router({mergeParams: true})
 
   settingsRouter.route('/settings')
+    .all(requiresLogin)
     .post(settingsController.save)
     .get(settingsController.read)
 


### PR DESCRIPTION
If the user continues using the app after having timed out, all requests will fail, some silently. This PR instead clears the client session when the server signals a session timeout.

The main change was simple. In the api middleware, if a response has status 401, clear the user from client state. b1cbc57

To support this change the server needed to return 401 responses consistently when the user was not authenticated. 7262004

On logging out an admin, the formatting was off; there was an empty space where the sidebar used to be. This is because of DOM manipulation being done in `<Application />` using _jQuery_ instead of _React_. c0c9105.

The last change wasn't strictly necessary, it was a simple refactor I did while reviewing how the client handled authorization. I thought it might be useful in better enforcing guest only pages, but I didn't find anywhere else that I was certain needed it. Other than maybe `<ResetPassword />`. 3b48bc3

Closes #296. 