### PR TITLE
fixes #323 - aligns selectors in navbar in Firefox

### DIFF
--- a/client/modules/core/css/core.css
+++ b/client/modules/core/css/core.css
@@ -29,7 +29,8 @@ li.treeview > a > span::after {
   font-size: 10px;
   font-weight: 300;
   padding-right: 10px;
-  float: right;
+	position: absolute;
+  right: 0px;
   content: '\f078';
 }
 

--- a/client/modules/core/css/core.css
+++ b/client/modules/core/css/core.css
@@ -29,7 +29,7 @@ li.treeview > a > span::after {
   font-size: 10px;
   font-weight: 300;
   padding-right: 10px;
-	position: absolute;
+  position: absolute;
   right: 0px;
   content: '\f078';
 }


### PR DESCRIPTION
Removes float: right and instead uses absolute positioning, which seems to fix the Firefox-specific UI problem.