### PR TITLE
Capitalized the column heading status on the Packing List page

### DIFF
--- a/client/modules/food/components/packing/Packages.js
+++ b/client/modules/food/components/packing/Packages.js
@@ -79,7 +79,7 @@ class Packages extends Component {
               Packed By
             </TableHeaderColumn>
             <TableHeaderColumn dataField="status" >
-              status
+              Status
             </TableHeaderColumn>
             <TableHeaderColumn
               dataFormat={this.getActionButtons}


### PR DESCRIPTION
On the Packing List page the column heading 'status' was changed to 'Status' so it is capitalized like the other table headings.
This was suggested by @kenjiO 