### PR TITLE
Allow guests to get settings

### DIFF
--- a/server/routes/settings.js
+++ b/server/routes/settings.js
@@ -9,8 +9,7 @@ export default () => {
   const settingsRouter = Router({mergeParams: true})
 
   settingsRouter.route('/settings')
-    .all(requiresLogin)
-    .post(settingsController.save)
+    .post(requiresLogin, settingsController.save)
     .get(settingsController.read)
 
   return settingsRouter


### PR DESCRIPTION
Recent changes (by me) to authorization mistakenly required a logged in user in
order to access the settings. These are required to render the content
pages, so everyone should have access to them.