### PR TITLE
Do not require name for <Checkbox>

### DIFF
--- a/client/components/form/Checkbox.js
+++ b/client/components/form/Checkbox.js
@@ -4,7 +4,7 @@ import {compose, setPropTypes, withHandlers} from 'recompose'
 import {Checkbox as RBCheckbox} from 'react-bootstrap'
 
 const withPropTypes = setPropTypes({
-  name: P.any.isRequired,
+  name: P.any,
   label: P.string,
   readOnly: P.bool,
   onClick: P.func,


### PR DESCRIPTION
The prop was marked as required but was often not provided.