### PR TITLE
Fix spelling error in profile controller

### DIFF
--- a/server/controllers/users/profile.js
+++ b/server/controllers/users/profile.js
@@ -1,6 +1,6 @@
 import {extend} from 'lodash'
 
-import {BadRequestError, UnauthorizedError} from '../../lib/errors'
+import {BadRequestError} from '../../lib/errors'
 import User from '../../models/user'
 
 /**
@@ -36,13 +36,13 @@ export const update = async function(req, res) {
   // For security measurement we remove the roles from the req.body object
   delete req.body.roles
 
-  if (!user) throw new UnauthorizedError
   // Merge existing user
   user = extend(user, req.body)
+
+  if (!user.firstName || !user.lastName) throw new BadRequestError('First Name and Last Name are required')
+
   user.updated = Date.now()
   user.displayName = user.firstName + ' ' + user.lastName
-
-  if (!user.firstName || !user.lastName) throw new BadRequestError("Fist Name and Last Name are required")
 
   const sameEmail = await User.findOne({email: req.user.email}).lean()
   if (sameEmail && sameEmail._id !== req.user._id)

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -2,6 +2,7 @@ import Router from 'express-promise-router'
 import passport from 'passport'
 import users from '../controllers/users'
 
+const {requiresLogin} = users
 const userRouter = Router({mergeParams: true})
 
 export default () => {
@@ -11,7 +12,7 @@ export default () => {
   userRouter.route('/users/me').get(users.me)
 
   userRouter.route('/users/:userId').get(users.getById)
-  userRouter.route('/users').put(users.update)
+  userRouter.route('/users').put(requiresLogin, users.update)
 
   // Setting up the users password api
   userRouter.route('/users/password').post(users.changePassword)


### PR DESCRIPTION
"Fist Name" => "First Name"

While I was there I made use of the `usersController.requiresLogin()` middleware to enforce a signed in user, just to keep things consistent.

Also, `user = extend(user, req.body)` is a little misleading. `lodash.extend()` already mutates the object so there is no need to assign to `user` again. Only meaningful if you were expecting `req.user` to remain untouched, but I thought I'd bring it up.