### PR TITLE
Use appropriate user in profile.update()

### DIFF
--- a/server/controllers/users/profile.js
+++ b/server/controllers/users/profile.js
@@ -32,6 +32,8 @@ export const getById = async function(req, res) {
  */
 export const update = async function(req, res) {
   let user = req.user
+  if (user._id !== req.body._id)
+    user = await User.findById(req.body._id).lean()
 
   // For security measurement we remove the roles from the req.body object
   delete req.body.roles


### PR DESCRIPTION
Although the endpoint is used to update any user, it always used the logged in user (`req.user`) as the base.