### PR TITLE
Filter params in controller

### DIFF
--- a/server/controllers/customer.js
+++ b/server/controllers/customer.js
@@ -1,4 +1,4 @@
-import {extend, intersection, includes} from 'lodash'
+import {extend, intersection, includes, omit} from 'lodash'
 
 import {ForbiddenError, NotFoundError} from '../lib/errors'
 import {ADMIN_ROLE, clientRoles, volunteerRoles, customerStatus} from '../../common/constants'
@@ -15,7 +15,7 @@ export default {
    * Create a customer
    */
   async create(req, res) {
-    let customer = new Customer(req.body)
+    let customer = new Customer(omit(req.body, ['status']))
     customer._id = req.user.id
 
     await User.findOneAndUpdate(

--- a/server/controllers/donation.js
+++ b/server/controllers/donation.js
@@ -1,3 +1,4 @@
+import {pick} from 'lodash'
 import {ADMIN_ROLE} from '../../common/constants'
 import Donation from '../models/donation'
 import Donor from '../models/donor'
@@ -7,9 +8,8 @@ import mailer from '../lib/mail/mail-helpers'
 
 export default {
   async create(req, res) {
-
     let newDonation = {
-      ...req.body,
+      ...(pick(req.body, ['donor', 'description', 'items'])),
       total: req.body.items.reduce((acc, item) => {
         if (isNaN(Number(item.value))) {
           throw new BadRequestError

--- a/server/controllers/donor.js
+++ b/server/controllers/donor.js
@@ -1,4 +1,5 @@
 import extend from 'lodash/extend'
+import {omit} from 'lodash'
 
 import {ForbiddenError, NotFoundError} from '../lib/errors'
 import {ADMIN_ROLE, clientRoles} from '../../common/constants'
@@ -12,7 +13,7 @@ export default {
    */
   async create(req, res) {
     const donor = new Donor({
-      ...req.body,
+      ...(omit(req.body, ['status', 'donations'])),
       _id: req.user.id
     })
 

--- a/server/controllers/users/authentication.js
+++ b/server/controllers/users/authentication.js
@@ -1,4 +1,4 @@
-import {map} from 'lodash'
+import {map, pick} from 'lodash'
 import passport from 'passport'
 
 import {UnauthorizedError, ValidationError} from '../../lib/errors'
@@ -10,7 +10,7 @@ import User from '../../models/user'
 export const signup = async function(req, res) {
   // Init Variables
   let user = new User({
-    ...req.body,
+    ...(pick(req.body, ['firstName', 'lastName', 'email', 'password'])),
     roles: [],
     provider: 'local',
     displayName: `${req.body.firstName} ${req.body.lastName}`

--- a/server/controllers/users/profile.js
+++ b/server/controllers/users/profile.js
@@ -1,4 +1,4 @@
-import {extend} from 'lodash'
+import {extend, pick} from 'lodash'
 
 import {BadRequestError} from '../../lib/errors'
 import User from '../../models/user'
@@ -35,11 +35,8 @@ export const update = async function(req, res) {
   if (user._id !== req.body._id)
     user = await User.findById(req.body._id).lean()
 
-  // For security measurement we remove the roles from the req.body object
-  delete req.body.roles
-
   // Merge existing user
-  user = extend(user, req.body)
+  extend(user, pick(req.body, ['firstName', 'lastName', 'email']))
 
   if (!user.firstName || !user.lastName) throw new BadRequestError('First Name and Last Name are required')
 

--- a/server/controllers/volunteer.js
+++ b/server/controllers/volunteer.js
@@ -1,4 +1,4 @@
-import {difference, extend} from 'lodash'
+import {difference, extend, omit} from 'lodash'
 
 import {ForbiddenError, NotFoundError} from '../lib/errors'
 import {ADMIN_ROLE, clientRoles} from '../../common/constants'
@@ -11,7 +11,7 @@ export default {
    * Create a volunteer
    */
   async create(req, res) {
-    let volunteer = new Volunteer(req.body)
+    let volunteer = new Volunteer(omit(req.body, ['status', 'customers']))
     volunteer._id = req.user.id
     volunteer.user = req.user.id
 


### PR DESCRIPTION
Instead of dumping whatever the user gives you into a model, selectively take or reject specific keys.

I was a little uncertain about the client controllers. I wrote something for the create method, but I imagine that `email`, `firstName`, and `lastName` could be omitted as well, instead pulling those values off of the related user. Unless there is a reason to allow those values to diverge.

I didn't touch the update method. It's probably fine as the authorizations are restricted to admins and the clients themselves, but it's worth some thought.

Addresses #337, not sure if it resolves it though.