### PR TITLE
Fix profile controller update method

### DIFF
--- a/server/controllers/users/profile.js
+++ b/server/controllers/users/profile.js
@@ -49,16 +49,20 @@ export const update = async function(req, res) {
     throw new BadRequestError('Email address is taken')
 
   // Update admin status
-  if (includes(req.user, ADMIN_ROLE)) {
-    const alreadyAdmin = includes(user.roles, ADMIN_ROLE)
-    if (user.isAdmin && !alreadyAdmin) {
+  const authenticatedUserIsAdmin = includes(req.user.roles, ADMIN_ROLE)
+
+  if (authenticatedUserIsAdmin) {
+    const previouslyAdmin = includes(user.roles, ADMIN_ROLE)
+    const currentlyAdmin = req.body.isAdmin
+
+    if (currentlyAdmin && !previouslyAdmin) {
       user.roles.push(ADMIN_ROLE)
-    } else if (!user.isAdmin && alreadyAdmin) {
-      if (parseInt(req.params.userId, 10) === req.user._id)
+    } else if (!currentlyAdmin && previouslyAdmin) {
+      if (user._id === req.user._id)
         throw new BadRequestError('You are not allowed to demote yourself')
+
       user.roles.splice(user.roles.indexOf(ADMIN_ROLE), 1)
     }
-    delete user.isAdmin
   }
 
   await user.save()

--- a/server/tests/unit/profile.spec.js
+++ b/server/tests/unit/profile.spec.js
@@ -1,0 +1,47 @@
+import { includes } from 'lodash'
+
+import { ADMIN_ROLE } from '../../../common/constants'
+import * as controller from '../../controllers/users/profile'
+import User from '../../models/user'
+
+import { createTestUser } from '../helpers'
+
+describe('Profile controller', function() {
+  before(async function() {
+    await initDb()
+  })
+
+  beforeEach(async function() {
+    await User.find().remove()
+  })
+
+  after(async function() {
+    await resetDb()
+  })
+
+  describe('update()', function() {
+    it('toggles admin role', async function() {
+      const req = {
+        user: { _id: -1, roles: [ADMIN_ROLE] },
+        body: {}
+      }
+      const res = { json: () => {} }
+      let editedUser = await User.create(createTestUser('admin', ADMIN_ROLE))
+      req.body._id = editedUser._id
+
+      // toggle admin off
+      req.body.isAdmin = false
+      await controller.update(req, res)
+
+      editedUser = await User.findById(editedUser._id)
+      expect(includes(editedUser.roles, ADMIN_ROLE)).to.be.false
+
+      // toggle admin on
+      req.body.isAdmin = true
+      await controller.update(req, res)
+      
+      editedUser = await User.findById(editedUser._id)
+      expect(includes(editedUser.roles, ADMIN_ROLE)).to.be.true
+    })
+  })
+})

--- a/server/tests/unit/profile.spec.js
+++ b/server/tests/unit/profile.spec.js
@@ -3,6 +3,7 @@ import { includes } from 'lodash'
 import { ADMIN_ROLE } from '../../../common/constants'
 import * as controller from '../../controllers/users/profile'
 import User from '../../models/user'
+import { BadRequestError } from '../../lib/errors'
 
 import { createTestUser } from '../helpers'
 
@@ -43,5 +44,20 @@ describe('Profile controller', function() {
       editedUser = await User.findById(editedUser._id)
       expect(includes(editedUser.roles, ADMIN_ROLE)).to.be.true
     })
+  })
+
+  it('cannot demote self', async function() {
+    let user = await User.create(createTestUser('admin', ADMIN_ROLE))
+    const req = { 
+      user,
+      body: { _id: user.id, isAdmin: false }
+    }
+    const res = {}
+
+    try {
+      await controller.update(req, res)
+    } catch (err) {
+      expect(err).to.be.an.instanceof(BadRequestError)
+    }
   })
 })


### PR DESCRIPTION
The recently added param filtering removed `isAdmin` from user, which prevents the admin toggle from working.

Also fixed the cannot demote self check. Was using `userId` from params, but against convention, the id is not included in the path but the request body.

The admin toggle code was refactored for clarity and a test was added.

Now that I look at it, I had to change the authenticated user is admin check as well. Not sure how this was working before...