### PR TITLE
Limit route requests

### DIFF
--- a/client/modules/driver/components/DriverRoute.js
+++ b/client/modules/driver/components/DriverRoute.js
@@ -87,11 +87,19 @@ class DriverRoute extends Component {
               <Box>
                 <BoxHeader heading="Edit Route">
                   <div className="box-tools">
-                    <Button bsStyle="primary" onClick={this.requestRoute}>
+                    <Button
+                      bsStyle="primary"
+                      disabled={waypoints.length <= 2}
+                      onClick={this.requestRoute}
+                    >
                       Route
                     </Button>
                     {' '}
-                    <Button bsStyle="success" onClick={this.requestOptimized}>
+                    <Button
+                      bsStyle="success"
+                      disabled={waypoints.length <= 2}
+                      onClick={this.requestOptimized}
+                    >
                       Optimize
                     </Button>
                     {' '}

--- a/client/modules/driver/components/DriverRoute.js
+++ b/client/modules/driver/components/DriverRoute.js
@@ -32,7 +32,8 @@ const mapStateToProps = (state, ownProps) => ({
     selectors.questionnaire.loading(state) || selectors.settings.fetching(state),
   loadError: selectors.volunteer.loadError(state) || selectors.customer.loadError(state) ||
     selectors.questionnaire.loadError(state) || selectors.settings.error(state),
-  routeError: selectors.delivery.route.hasError(state)
+  routeError: selectors.delivery.route.hasError(state),
+  routeLoading: selectors.delivery.route.isFetching(state)
 })
 
 const mapDispatchToProps = (dispatch, ownProps) => ({
@@ -77,7 +78,7 @@ class DriverRoute extends Component {
   }
 
   render() {
-    const {driver, settings, waypoints, loading, loadError, routeError} = this.props
+    const {driver, settings, waypoints, loading, loadError, routeError, routeLoading} = this.props
 
     return (
       <Page>
@@ -89,7 +90,7 @@ class DriverRoute extends Component {
                   <div className="box-tools">
                     <Button
                       bsStyle="primary"
-                      disabled={waypoints.length <= 2}
+                      disabled={waypoints.length <= 2 || routeLoading}
                       onClick={this.requestRoute}
                     >
                       Route
@@ -97,7 +98,7 @@ class DriverRoute extends Component {
                     {' '}
                     <Button
                       bsStyle="success"
-                      disabled={waypoints.length <= 2}
+                      disabled={waypoints.length <= 2 || routeLoading}
                       onClick={this.requestOptimized}
                     >
                       Optimize

--- a/client/modules/driver/components/driver-assignment/SelectedDriver.js
+++ b/client/modules/driver/components/driver-assignment/SelectedDriver.js
@@ -18,7 +18,8 @@ const mapStateToProps = state => ({
   selectedCustomerIds: selectors.delivery.assignment.getSelectedCustomerIds(state),
   route: selectors.delivery.route.getRoute(state),
   waypoints: selectors.delivery.route.getAllWaypoints(state),
-  customerWaypoints: selectors.delivery.route.getWaypoints(state)
+  customerWaypoints: selectors.delivery.route.getWaypoints(state),
+  routeLoading: selectors.delivery.route.isFetching(state)
 })
 
 const mapDispatchToProps = dispatch => ({
@@ -51,7 +52,8 @@ const DriverListDetail = ({
   requestRoute,
   saveRoute,
   route,
-  waypoints
+  waypoints,
+  routeLoading
 }) =>
   <ListGroupItem>
     <div style={{display: 'flex'}}>
@@ -97,7 +99,7 @@ const DriverListDetail = ({
         <Button
           bsStyle="primary"
           onClick={requestRoute}
-          disabled={waypoints.length <= 2}
+          disabled={waypoints.length <= 2 || routeLoading}
           style={{ margin: '10px 10px 0 0' }}
         >
           Suggest Route

--- a/client/modules/driver/reducers/route.js
+++ b/client/modules/driver/reducers/route.js
@@ -83,7 +83,11 @@ export const moveWaypoint = (waypoint, idx, getWaypoints) => (dispatch, getState
   // )
 }
 
-export const requestGoogleRoute = (waypoints, optimize) => dispatch => {
+export const requestGoogleRoute = (waypoints, optimize) => (dispatch, getState) => {
+  // TODO: this should be using selectors, but the needed ones are defined here
+  if (getState().delivery.route.fetching)
+    return Promise.reject(new Error('Already requesting a route'))
+
   dispatch(routeRequest())
   return getGoogleRoute(waypoints, optimize)
     .then(res => {

--- a/client/modules/driver/reducers/route.spec.js
+++ b/client/modules/driver/reducers/route.spec.js
@@ -46,10 +46,11 @@ describe('route reducer', function() {
       }]
 
       const dispatchMock = sinon.spy()
+      const getStateFake = () => ({delivery: {route: {fetching: false }}})
       const getGoogleRouteMock = sinon.stub().resolves({routes})
 
       reducer.default.__Rewire__('getGoogleRoute', getGoogleRouteMock)
-      const result = reducer.requestGoogleRoute(allWaypoints, true)(dispatchMock)
+      const result = reducer.requestGoogleRoute(allWaypoints, true)(dispatchMock, getStateFake)
       reducer.default.__ResetDependency__('getGoogleRoute')
 
       expect(dispatchMock.firstCall).to.have.been.calledWith({


### PR DESCRIPTION
These are time-consuming and expensive requests, so I limited them to one outgoing.

I hard-coded the selector in [the route "reducer"](https://github.com/freeCodeCamp/pantry-for-good/compare/staging...wacii:feature/limit-route-requests?expand=1#diff-c891cd2901f7fe7ee3be201fef407506R88). The route selector factory is defined in the same file, so I can't reference the ultimate selectors without pulling apart the reducer file.