### PR TITLE
Revise customer integration tests

### DIFF
--- a/client/modules/customer/reducer.js
+++ b/client/modules/customer/reducer.js
@@ -11,7 +11,7 @@ export const actions = crudActions('customer')
 
 export const loadCustomers = () => ({
   [CALL_API]: {
-    endpoint: 'customer',
+    endpoint: 'admin/customer',
     schema: arrayOfCustomers,
     types: [actions.LOAD_ALL_REQUEST, actions.LOAD_ALL_SUCCESS, actions.LOAD_ALL_FAILURE]
   }

--- a/client/modules/customer/reducer.spec.js
+++ b/client/modules/customer/reducer.spec.js
@@ -12,7 +12,7 @@ describe('customer reducer', function() {
       expect(action).to.have.property(CALL_API)
       const {endpoint, schema, types} = action[CALL_API]
 
-      expect(endpoint).to.equal('customer')
+      expect(endpoint).to.equal('admin/customer')
       expect(schema).to.equal(arrayOfCustomers)
       expect(types.length).to.equal(3)
     })

--- a/server/routes/customer.js
+++ b/server/routes/customer.js
@@ -16,12 +16,13 @@ export default () => {
   const customerRouter = Router({mergeParams: true})
 
   customerRouter.route('/customer')
-    .get(requiresLogin, hasAuthorization, customerController.list)
     .post(requiresLogin, customerController.create)
 
   customerRouter.route('/customer/:customerId')
     .get(requiresLogin, hasAuthorization, customerController.read)
     .put(requiresLogin, hasAuthorization, canChangeStatus, customerController.update)
+
+  customerRouter.get('/admin/customer', customerController.list)
 
   customerRouter.route('/admin/customers/:customerId')
     .put(websocketMiddleware(saveSchema), customerController.update)

--- a/server/routes/customer.js
+++ b/server/routes/customer.js
@@ -24,7 +24,6 @@ export default () => {
     .put(requiresLogin, hasAuthorization, canChangeStatus, customerController.update)
 
   customerRouter.route('/admin/customers/:customerId')
-    .get(customerController.read)
     .put(websocketMiddleware(saveSchema), customerController.update)
     .delete(websocketMiddleware(deleteSchema), customerController.delete)
 

--- a/server/tests/helpers.js
+++ b/server/tests/helpers.js
@@ -28,6 +28,19 @@ export const createUserSession = async function(userModel) {
 }
 
 /**
+ * create an express app without an authenticated user
+ * 
+ * @return {object}
+ */
+export const createGuestSession = function() {
+  setupPassport()
+  const mockApp = express()
+  mockApp.use(app())
+
+  return mockApp
+}
+
+/**
  * create a user model
  *
  * @param {string} username

--- a/server/tests/integration/customer.spec.js
+++ b/server/tests/integration/customer.spec.js
@@ -199,7 +199,7 @@ describe('Customer Api', function() {
       await customerReq.post('/api/customer')
         .send(customer.user)
 
-      return adminReq.get(`/api/customer`)
+      return adminReq.get(`/api/admin/customer`)
         .expect(res => {
           expect(res.body).to.be.an('array')
           expect(res.body).to.have.lengthOf(1)
@@ -214,7 +214,7 @@ describe('Customer Api', function() {
 
       const customerReq = supertest.agent(customer.app)
 
-      return customerReq.get(`/api/customer`)
+      return customerReq.get(`/api/admin/customer`)
         .expect(res => {
           expect(res.body).to.be.an('object')
           expect(res.body).to.have.property('message', 'User is not authorized')

--- a/server/tests/integration/customer.spec.js
+++ b/server/tests/integration/customer.spec.js
@@ -6,7 +6,7 @@ import {
 } from '../../../common/constants'
 import Customer from '../../models/customer'
 import Volunteer from '../../models/volunteer'
-import {createUserSession, createTestUser} from '../helpers'
+import {createGuestSession, createUserSession, createTestUser} from '../helpers'
 import User from '../../models/user'
 import Questionnaire from '../../models/questionnaire'
 import Food, {FoodItem} from '../../models/food'
@@ -42,7 +42,14 @@ describe('Customer Api', function() {
     await resetDb()
   })
 
-  describe('User routes', function() {
+  describe('POST /api/customer', function() {
+    it('requires login', async function() {
+      const app = createGuestSession()
+      const request = supertest.agent(app)
+
+      return request.post('/api/customer').expect(401)
+    })
+
     it('creates customers', async function() {
       const newCustomer = createTestUser('user', clientRoles.CUSTOMER)
       const {user, app} = await createUserSession(newCustomer)
@@ -74,7 +81,9 @@ describe('Customer Api', function() {
         })
         .expect(400)
     })
+  })
 
+  describe('User routes', function() {
     it('shows a customer', async function() {
       const newCustomer = createTestUser('user', clientRoles.CUSTOMER)
       const {user, app} = await createUserSession(newCustomer)

--- a/server/tests/integration/customer.spec.js
+++ b/server/tests/integration/customer.spec.js
@@ -249,20 +249,6 @@ describe('Customer Api', function() {
         .expect(200)
     })
 
-    it('rejects non-admins', async function() {
-      const newCustomer = createTestUser('user', clientRoles.CUSTOMER)
-      const customer = await createUserSession(newCustomer)
-
-      const customerReq = supertest.agent(customer.app)
-
-      return customerReq.get(`/api/admin/customer`)
-        .expect(res => {
-          expect(res.body).to.be.an('object')
-          expect(res.body).to.have.property('message', 'User is not authorized')
-        })
-        .expect(403)
-    })
-
     it('deletes customers', async function() {
       const newAdmin = createTestUser('admin', ADMIN_ROLE)
       const newCustomer = createTestUser('user', clientRoles.CUSTOMER)


### PR DESCRIPTION
Separated the tests into endpoints to better see what was and wasn't being tested.

Removed a duplicate read customer route and moved the list customer route under admin. That is how it was being used anyways.