### PR TITLE
Refactor FoodItems into two components

### DIFF
--- a/client/modules/food/components/inventory/FoodAddEditForm.js
+++ b/client/modules/food/components/inventory/FoodAddEditForm.js
@@ -1,0 +1,192 @@
+import React from 'react'
+import { Button, FormGroup, FormControl, ControlLabel } from 'react-bootstrap'
+import Autosuggest from 'react-bootstrap-autosuggest'
+
+import { Box, BoxHeader, BoxBody } from '../../../../components/box'
+
+export default class FoodAddEditForm extends React.Component {
+  constructor(props) {
+    super(props)
+    this.state = {
+      formInputFields: {
+        name: this.props.editFood ? this.props.editFood.name : "",
+        categoryId: this.props.editFood ? this.props.editFood.categoryId : "",
+        quantity: this.props.editFood ? this.props.editFood.quantity : ""
+      },
+      validInput: false,
+      //touched input fields
+      touched: { foodName: false, foodCategory: false, foodQuantity: false },
+    }
+  }
+
+  componentWillReceiveProps = nextProps => {
+    // If the modal is open and a save is complete, close the modal
+    if (this.props.saving && !nextProps.saving && !nextProps.saveError) {
+      this.props.closeModal()
+    }
+  }
+
+  getValidationState = {
+    // The following 3 functions validate the individual input fields and return the validation state used for react-bootstrap-table
+    foodName: () =>
+      !this.state.touched.foodName || this.state.formInputFields.name.trim().length ? null : 'error',
+    foodQuantity: () =>
+      !this.state.touched.foodQuantity || (this.state.formInputFields.quantity !== "" && this.state.formInputFields.quantity >= 0) ? null : 'error',
+    foodCategory: () =>
+      !this.state.touched.foodCategory || (this.state.formInputFields.categoryId !== "") ? null : 'error',
+    // This returns true or false if all fields are valid
+    all: () =>
+      this.state.formInputFields.name.trim().length > 0 &&
+      this.state.formInputFields.quantity !== "" &&
+      this.state.formInputFields.quantity >= 0 &&
+      this.state.formInputFields.categoryId !== ""
+  }
+
+  /**
+   * Re-computes the value for state.validInput
+   */
+  validate = () => {
+    this.setState({ validInput: this.getValidationState.all() && this.checkChanged() })
+  }
+
+  /**
+   *  check whether newly edited values are different from the inital values
+   */
+  checkChanged = () => {
+    const initialformInputFields = {
+      name: this.props.editFood ? this.props.editFood.name : "",
+      categoryId: this.props.editFood ? this.props.editFood.categoryId : "",
+      quantity: this.props.editFood ? this.props.editFood.quantity : ""
+    }
+    return Object.keys(this.state.formInputFields).map(key =>
+      initialformInputFields[key] !== this.state.formInputFields[key]
+    ).reduce((acc, x) => acc || x, false)
+  }
+
+  /**
+   * functions to handle any changes of user input fields in the add/edit form
+   */
+  handleChange = {
+    foodName: value => {
+      if (typeof value === 'object' && value !== null) {
+        // The user entered an existing food name and autosuggest provided the object for that food
+        this.setState({
+          formInputFields: {
+            ...this.state.formInputFields,
+            name: value.name,
+            categoryId: value.categoryId
+          },
+          touched: { ...this.state.touched, foodName: true }
+        })
+      } else {
+        // The user entered a food name that was not found by autosuggest
+        this.setState({
+          formInputFields: {
+            ...this.state.formInputFields,
+            name: value || ""
+          },
+          touched: { ...this.state.touched, foodName: true }
+        }, this.validate)
+      }
+    },
+    foodQuantity: e =>
+      this.setState({
+        formInputFields: { ...this.state.formInputFields, quantity: e.target.value },
+        touched: { ...this.state.touched, foodQuantity: true }
+      }, this.validate),
+    foodCategory: e =>
+      this.setState({
+        formInputFields: { ...this.state.formInputFields, categoryId: e.target.value },
+        touched: { ...this.state.touched, foodCategory: true }
+      }, this.validate)
+  }
+
+  saveFood = () => {
+    if (this.props.editFood) {
+      this.props.saveFoodItem(
+        this.props.editFood.categoryId,
+        {
+          ...this.props.editFood,
+          name: this.state.formInputFields.name,
+          categoryId: this.state.formInputFields.categoryId,
+          quantity: this.state.formInputFields.quantity
+        }
+      )
+    } else if (this.props.formType === 'Add') {
+      this.props.saveFoodItem(
+        this.state.formInputFields.categoryId,
+        {
+          name: this.state.formInputFields.name,
+          categoryId: this.state.formInputFields.categoryId,
+          quantity: this.state.formInputFields.quantity
+        }
+      )
+    }
+  }
+
+  render = () => {
+    return (
+      <Box>
+        <BoxHeader>
+          {this.props.formType} Food
+        </BoxHeader>
+        <BoxBody
+          loading={this.props.loading || this.props.saving}
+          error={this.props.saveError}
+          errorBottom={true}>
+          <form>
+
+            <FormGroup controlId="foodName" validationState={this.getValidationState.foodName()} >
+              <ControlLabel>Food Name</ControlLabel>
+              <Autosuggest
+                value={this.state.formInputFields.name}
+                datalist={this.props.foodItems}
+                placeholder="Food Name"
+                itemValuePropName='name'
+                itemReactKeyPropName='name'
+                itemSortKeyPropName='nameLowerCased'
+                onSelect={this.handleChange.foodName}
+                autoFocus={this.props.formType === 'Add'}
+              />
+            </FormGroup>
+
+            <FormGroup controlId="foodCategory" validationState={this.getValidationState.foodCategory()}>
+              <ControlLabel>Category</ControlLabel>
+              <FormControl componentClass="select" placeholder="select category"
+                onChange={this.handleChange.foodCategory}
+                value={this.state.formInputFields.categoryId}
+              >
+                {(this.props.formType === 'Add') &&
+                  <option value="">Select Category</option>
+                }
+                {this.props.foodCategories.map(category =>
+                  <option key={category._id} value={category._id}>{category.category}</option>
+                )}
+              </FormControl>
+            </FormGroup>
+
+            <FormGroup controlId="foodQuantity" validationState={this.getValidationState.foodQuantity()} >
+              <ControlLabel>Quantity</ControlLabel>
+              <FormControl
+                type="number"
+                min="0"
+                value={this.state.formInputFields.quantity}
+                placeholder="Quantity"
+                onChange={this.handleChange.foodQuantity}
+                inputRef={ref => { this.quantityFormControl = ref }}
+              />
+            </FormGroup>
+          </form>
+          <div className="pull-right btn-toolbar">
+            <Button onClick={this.props.closeModal}>Cancel</Button>
+            <Button className={this.state.validInput && 'btn-success'}
+              onClick={this.saveFood}
+              disabled={!this.state.validInput || this.props.saving}>
+              {this.props.formType === 'Add' ? 'Add' : 'Update'}
+            </Button>
+          </div>
+        </BoxBody>
+      </Box>
+    )
+  }
+}

--- a/client/modules/food/components/inventory/FoodAddEditForm.spec.js
+++ b/client/modules/food/components/inventory/FoodAddEditForm.spec.js
@@ -1,0 +1,337 @@
+import React from 'react'
+import { shallow } from 'enzyme'
+
+import FoodAddEditForm from './FoodAddEditForm'
+
+describe('FoodAddEditForm', () => {
+  let props
+
+  beforeEach(() => {
+    props = {
+      FoodAddEditForm: [],
+      foodCategories: [],
+      loading: false,
+      saving: false,
+      saveFoodItem: sinon.spy(),
+      formType: "Add",
+      closeModal: sinon.spy()
+    }
+  })
+
+  it('sets state when constructed', () => {
+    const wrapper = shallow(<FoodAddEditForm {...props} />)
+    expect(wrapper.state().formInputFields).to.deep.equal({ name: "", categoryId: "", quantity: "" })
+    expect(wrapper.state().validInput).to.be.false
+    expect(wrapper.state().touched).to.deep.equal({foodName: false, foodCategory: false, foodQuantity: false})
+  })
+
+  it('componentWillReceiveProps closes modal if a save is complete', () => {
+    const wrapper = shallow(<FoodAddEditForm {...props} />)
+    wrapper.setProps({ saving: true })
+    const nextProps = {
+      saving: false,
+      saveError: undefined
+    }
+    expect(props.closeModal.called).to.be.false
+    wrapper.setProps(nextProps)
+    expect(props.closeModal.called).to.be.true
+  })
+
+  it('componentWillReceiveProps will not close a modal if in process of saving', () => {
+    const wrapper = shallow(<FoodAddEditForm {...props} />)
+    wrapper.setProps({ saving: false })
+    const nextProps = {
+      saving: true
+    }
+    wrapper.setProps(nextProps)
+    expect(props.closeModal.called).to.be.false
+  })
+
+  it('componentWillReceiveProps will not close a modal if there is a save error', () => {
+    const wrapper = shallow(<FoodAddEditForm {...props} />)
+    wrapper.setProps({ saving: true })
+    const nextProps = {
+      saving: false,
+      saveError: { message: 'error' }
+    }
+    wrapper.setProps(nextProps)
+    expect(props.closeModal.called).to.be.false
+  })
+
+  describe('getValidationState', () => {
+    it('foodName() returns null for a valid name', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc' } })
+      expect(instance.getValidationState.foodName()).to.be.null
+    })
+
+    it('foodName() returns error for an empty string', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: '' }, touched: { foodName: true } })
+      expect(instance.getValidationState.foodName()).to.equal('error')
+    })
+
+    it('foodName() returns error for a whitespace string', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: ' ' }, touched: { foodName: true } })
+      expect(instance.getValidationState.foodName()).to.equal('error')
+    })
+
+    it('foodQuantity() returns null for 0', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', quantity: '0' }, touched: { foodQuantity: true } })
+      expect(instance.getValidationState.foodQuantity()).to.be.null
+    })
+
+    it('foodQuantity() returns null for 1', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', quantity: '1' }, touched: { foodQuantity: true } })
+      expect(instance.getValidationState.foodQuantity()).to.be.null
+    })
+
+    it('foodQuantity() returns null for 623', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', quantity: '623' }, touched: { foodQuantity: true } })
+      expect(instance.getValidationState.foodQuantity()).to.be.null
+    })
+
+    it('foodQuantity() returns error for -1', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', quantity: '-1' }, touched: { foodQuantity: true } })
+      expect(instance.getValidationState.foodQuantity()).to.equal('error')
+    })
+
+    it('foodQuantity() returns error for an empty string', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', quantity: '' }, touched: { foodQuantity: true } })
+      expect(instance.getValidationState.foodQuantity()).to.equal('error')
+    })
+
+    it('foodQuantity() returns error for a non-numeric string', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', quantity: 'a1' }, touched: { foodQuantity: true } })
+      expect(instance.getValidationState.foodQuantity()).to.equal('error')
+    })
+
+    it('foodCategory() returns null for a non-empty string', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', categoryId: '11' }, touched: { foodCategory: true } })
+      expect(instance.getValidationState.foodCategory()).to.be.null
+    })
+
+    it('foodCategory() returns error for an empty string', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({ formInputFields: { name: 'abc', categoryId: '' }, touched: { foodCategory: true } })
+      expect(instance.getValidationState.foodCategory()).to.equal('error')
+    })
+
+    it('getAll() returns true when name, category and quantity are all valid', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      const state = {
+        formInputFields: { name: 'abc', categoryId: '12', quantity: '5' },
+        touched: { foodName: true, foodCategory: true, foodQuantity: true }
+      }
+      instance.setState(state)
+      expect(instance.getValidationState.all()).to.be.true
+    })
+
+    it('getAll() returns false when name is not valid', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      const state = {
+        formInputFields: { name: '', categoryId: '12', quantity: '5' },
+        touched: { foodName: true, foodCategory: true, foodQuantity: true }
+      }
+      instance.setState(state)
+      expect(instance.getValidationState.all()).to.be.false
+    })
+
+    it('getAll() returns false when category is not valid', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      const state = {
+        formInputFields: { name: 'abc', categoryId: '', quantity: '5' },
+        touched: { foodName: true, foodCategory: true, foodQuantity: true }
+      }
+      instance.setState(state)
+      expect(instance.getValidationState.all()).to.be.false
+    })
+
+    it('getAll() returns false when quantity is not valid', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      const state = {
+        formInputFields: { name: 'abc', categoryId: '12', quantity: '-5' },
+        touched: { foodName: true, foodCategory: true, foodQuantity: true }
+      }
+      instance.setState(state)
+      expect(instance.getValidationState.all()).to.be.false
+    })
+
+  })
+
+  describe('validate()', () => {
+    it('sets state.validInput true when getValidationState.all() and checkChanged()', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      sinon.stub(instance.getValidationState, "all").callsFake(() => true)
+      sinon.stub(instance, "checkChanged").callsFake(() => true)
+      instance.validate()
+      expect(instance.state.validInput).to.equal(true)
+    })
+
+    it('sets state.validInput false when !getValidationState.all() and checkChanged()', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      sinon.stub(instance.getValidationState, "all").callsFake(() => false)
+      sinon.stub(instance, "checkChanged").callsFake(() => true)
+      instance.validate()
+      expect(instance.state.validInput).to.equal(false)
+    })
+
+    it('sets state.validInput false when getValidationState.all() and !checkChanged()', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      sinon.stub(instance.getValidationState, "all").callsFake(() => true)
+      sinon.stub(instance, "checkChanged").callsFake(() => false)
+      instance.validate()
+      expect(instance.state.validInput).to.equal(false)
+    })
+
+    it('sets state.validInput false when !getValidationState.all() and !checkChanged()', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      sinon.stub(instance.getValidationState, "all").callsFake(() => false)
+      sinon.stub(instance, "checkChanged").callsFake(() => false)
+      instance.validate()
+      expect(instance.state.validInput).to.equal(false)
+    })
+  })
+
+  describe('checkChanged()', () => {
+    it('is false when formInputFields are the same as initialformInputFields', () => {
+      const instance = shallow(<FoodAddEditForm {...props} editFood={{name: 'abc', quantity: '5', categoryId: '123'}} />).instance()
+      instance.setState({formInputFields: { name: 'abc', quantity: '5', categoryId: '123'}})
+      expect(instance.checkChanged()).to.be.false
+    })
+
+    it('is true when formInputFields.name differs from initialformInputFields', () => {
+      const instance = shallow(<FoodAddEditForm {...props} editFood={{name: 'abc', quantity: '5', categoryId: '123'}} />).instance()
+      instance.setState({formInputFields: { name: 'xyz', quantity: '5', categoryId: '123'}})
+      expect(instance.checkChanged()).to.be.true
+    })
+
+    it('is true when formInputFields.quantity differs from initialformInputFields', () => {
+      const instance = shallow(<FoodAddEditForm {...props} editFood={{name: 'abc', quantity: '5', categoryId: '123'}} />).instance()
+      instance.setState({formInputFields: { name: 'abc', quantity: '3', categoryId: '123'}})
+      expect(instance.checkChanged()).to.be.true
+    })
+
+    it('is true when formInputFields.categoryId differs from initialformInputFields', () => {
+      const instance = shallow(<FoodAddEditForm {...props} editFood={{name: 'abc', quantity: '5', categoryId: '123'}} />).instance()
+      instance.setState({formInputFields: { name: 'abc', quantity: '5', categoryId: '456'}})
+      expect(instance.checkChanged()).to.be.true
+    })
+  })
+
+  describe('handleChange', () => {
+    it('foodName() when called with a string sets state.formInputFields.name', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      instance.handleChange.foodName('abcde')
+      expect(instance.state.formInputFields.name).to.equal('abcde')
+    })
+
+    it('foodName() when called with a string calls validate()', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      sinon.spy(instance, "validate")
+      instance.handleChange.foodName('abcde')
+      expect(instance.validate.called).to.be.true
+    })
+
+    it('foodName() when called with an object sets name and categoryId', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      instance.quantity = { focus: () => { } }
+      instance.handleChange.foodName({ name: 'xyz', categoryId: '5832' })
+      expect(instance.state.formInputFields.name).to.equal('xyz')
+      expect(instance.state.formInputFields.categoryId).to.equal('5832')
+    })
+
+    it('foodName() when called with null sets state.formInputFields.name to ""', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      instance.setState({ formInputFields: { name: 'abc' } })
+      instance.handleChange.foodName(null)
+      expect(instance.state.formInputFields.name).to.equal("")
+    })
+
+    it('foodName() when called with null calls validate()', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      sinon.spy(instance, "validate")
+      instance.handleChange.foodName(null)
+      expect(instance.validate.called).to.be.true
+    })
+
+    it('foodQuantity() sets state.formInputFields.quantity', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      instance.handleChange.foodQuantity({ target: { value: '20' } })
+      expect(instance.state.formInputFields.quantity).to.equal('20')
+    })
+
+    it('foodQuantity() calls validate()', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      sinon.spy(instance, "validate")
+      instance.handleChange.foodQuantity({ target: { value: '20' } })
+      expect(instance.validate.called).to.be.true
+    })
+
+    it('foodCategory() sets state.formInputFields.categoryId', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      instance.handleChange.foodCategory({ target: { value: '3732' } })
+      expect(instance.state.formInputFields.categoryId).to.equal('3732')
+    })
+
+    it('foodCategory() calls validate()', () => {
+      const instance = shallow(<FoodAddEditForm {...props} />).instance()
+      sinon.spy(instance, "validate")
+      instance.handleChange.foodCategory({ target: { value: '42623' } })
+      expect(instance.validate.called).to.be.true
+    })
+  })
+
+  describe('saveFood()', () => {
+    it('Calls props.saveFoodItem() when an editing a food', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} editFood={{id: '001', name: 'abc', categoryId: '123', quantity: '13'}}/>)
+      const instance = wrapper.instance()
+      instance.setState({
+        formInputFields: { name: 'xyz', categoryId: '456', quantity: '11' }
+      })
+      instance.saveFood()
+      expect(instance.props.saveFoodItem.called).to.be.true
+      expect(instance.props.saveFoodItem.args[0][0]).to.equal('123')
+      expect(instance.props.saveFoodItem.args[0][1]).to.deep.equal({ id: '001', name: 'xyz', categoryId: '456', quantity: '11' })
+    })
+
+    it('Calls props.saveFoodItem() when adding a food', () => {
+      const wrapper = shallow(<FoodAddEditForm {...props} />)
+      const instance = wrapper.instance()
+      instance.setState({
+        formInputFields: { name: 'abc', categoryId: '123', quantity: '11' }
+      })
+      instance.saveFood()
+      expect(instance.props.saveFoodItem.called).to.be.true
+      expect(instance.props.saveFoodItem.args[0][0]).to.equal('123')
+      expect(instance.props.saveFoodItem.args[0][1]).to.deep.equal({ name: 'abc', categoryId: '123', quantity: '11' })
+    })
+  })
+})

--- a/client/modules/food/components/inventory/FoodItems.js
+++ b/client/modules/food/components/inventory/FoodItems.js
@@ -1,79 +1,53 @@
 import React from 'react'
 import { connect } from 'react-redux'
-import { Button, Modal, FormGroup, FormControl, ControlLabel } from 'react-bootstrap'
-import {BootstrapTable, TableHeaderColumn, SizePerPageDropDown} from 'react-bootstrap-table'
-import Autosuggest from 'react-bootstrap-autosuggest'
+import { Button, Modal } from 'react-bootstrap'
+import { BootstrapTable, TableHeaderColumn, SizePerPageDropDown } from 'react-bootstrap-table'
 import _ from 'lodash'
 
 import selectors from '../../../../store/selectors'
 import { saveFoodItem, deleteFoodItem, clearFlags } from '../../reducers/item'
 import { Box, BoxBody } from '../../../../components/box'
 import { showConfirmDialog, hideDialog } from '../../../core/reducers/dialog'
+import FoodAddEditForm from './FoodAddEditForm'
 
 export class FoodItems extends React.Component {
   constructor(props) {
     super(props)
     this.state = {
-      // showModal can be false, "Add" or "Edit"
-      showModal: false,
-      // editModalFood is the food being edited in the edit modal
+      // When modalType is "Add" or "Edit" the addEdit modal is shown
+      modalType: undefined,
+      // editModalFood is the food being edited when the modalType is edit
       editModalFood: undefined,
-      modalInputFields: { name: "", categoryId: "", quantity: "" },
-      validInput: false,
-      searchText: "",
-      //touched input fields
-      touched: { foodName: false, foodCategory: false, foodQuantity: false },
-      //store initial value
-      initialModalInputFields: { name: "", categoryId: "", quantity: "" },
+      searchText: ""
     }
   }
 
-  componentWillReceiveProps = nextProps => {
-    // If the modal is open and a save is complete, close the modal
-    if (this.state.showModal &&
-        this.props.saving &&
-        !nextProps.saving &&
-        !nextProps.saveError) {
-      this.closeModal()
-    }
-  }
-
+  /**
+   * Show the modal to add or edit a food.  If _id is provided the modal shows the form
+   * to edit that food.  Otherwise it shows the form to add a new food.
+   */
   openModal = _id => () => {
-    if (typeof _id !== 'string') {
-      // Open the modal in 'add' mode
-      this.setState({
-        showModal: 'Add',
-        editModalFood: undefined,
-        modalInputFields: { name: "", categoryId: "", quantity: "" },
-        touched: { foodName: false, foodCategory: false, foodQuantity: false },
-      })
-    } else {
+    if (_id) {
       // Open the modal in 'edit' mode
       const food = this.props.foodItems.find(food => food._id === _id)
-      const inputFields = {
-        name: food.name,
-        categoryId: food.categoryId,
-        quantity: food.quantity.toString()
-      }
       this.setState({
-        showModal: 'Edit',
-        editModalFood: food,
-        initialModalInputFields: inputFields,
-        modalInputFields: inputFields,
-        touched: { foodName: true, foodCategory: true, foodQuantity: true },
+        modalType: 'Edit',
+        editModalFood: food
+      })
+    } else {
+      // Open the modal in 'add' mode
+      this.setState({
+        modalType: 'Add',
+        editModalFood: undefined
       })
     }
     this.props.clearFlags()
-
   }
 
   closeModal = () => {
     this.setState({
-      showModal: false,
+      modalType: undefined,
       editModalFood: undefined,
-      modalInputFields: { name: "", categoryId: "", quantity: "" },
-      touched: { foodName: false, foodCategory: false, foodQuantity: false },
-      validInput: false,
     })
     this.props.clearFlags()
   }
@@ -87,12 +61,12 @@ export class FoodItems extends React.Component {
   }
 
   /**
-   * Used by react-bootstrap-table to get the action buttons
+   * Used by react-bootstrap-table to get the Edit and Delete buttons for a row
    */
   getActionButtons = (cell, row) =>
     <div>
       <Button onClick={this.openModal(row._id)} bsStyle="primary" bsSize="xs">
-        <i className="fa fa-pencil" style={{marginRight: '8px'}} />Edit
+        <i className="fa fa-pencil" style={{ marginRight: '8px' }} />Edit
       </Button>
       {' '}
       <Button
@@ -106,144 +80,34 @@ export class FoodItems extends React.Component {
           'Delete Item'
         )}
         bsStyle="danger" bsSize="xs">
-        <i className="fa fa-trash" style={{marginRight: '8px'}} />Delete
+        <i className="fa fa-trash" style={{ marginRight: '8px' }} />Delete
       </Button>
     </div>
 
   /**
    * Used by react-bootstrap-table to get the table header
    */
-  createCustomToolBar = props => {
-    return (
-      <div style={{ margin: '3px 15px' }}>
-        <div className='box-header' style={{ display: 'inline-block' }}>
-          <h3 className='box-title'>Foods</h3>
-        </div>
-        <div style={{ display: 'inline-block', float: 'right', marginRight: '10px' }}>
-          <Button onClick={this.openModal()} className='btn-success' disabled={this.props.foodCategories.length === 0} style={{ color: 'white', width: '200px' }}>Add to Inventory</Button>
-        </div>
-        <div style={{ display: 'inline-block', float: 'right', marginRight: '10px' }}>
-          {props.components.searchPanel}
-        </div>
+  createCustomToolBar = props =>
+    <div style={{ margin: '3px 15px' }}>
+      <div className='box-header' style={{ display: 'inline-block' }}>
+        <h3 className='box-title'>Foods</h3>
       </div>
-    )
-  }
+      <div style={{ display: 'inline-block', float: 'right', marginRight: '10px' }}>
+        <Button onClick={this.openModal()} className='btn-success' disabled={this.props.foodCategories.length === 0} style={{ color: 'white', width: '200px' }}>Add to Inventory</Button>
+      </div>
+      <div style={{ display: 'inline-block', float: 'right', marginRight: '10px' }}>
+        {props.components.searchPanel}
+      </div>
+    </div>
 
-  getValidationState = {
-    // The following 3 functions validate the individual input fields and return the validation state used for react-bootstrap-table
-    foodName: () =>
-      !this.state.touched.foodName || this.state.modalInputFields.name.trim().length ? null : 'error',
-    foodQuantity: () =>
-      !this.state.touched.foodQuantity || (this.state.modalInputFields.quantity !== "" && this.state.modalInputFields.quantity >= 0) ? null : 'error',
-    foodCategory: () =>
-      !this.state.touched.foodCategory || (this.state.modalInputFields.categoryId !== "") ? null : 'error',
-    // This returns true or false if all fields are valid
-    all: () =>
-      this.getValidationState.foodName() === null &&
-      this.getValidationState.foodQuantity() === null &&
-      this.getValidationState.foodCategory() === null
-  }
-
-  /**
-   * Re-computes the value for state.validInput
-   */
-  validate = () => {
-    this.setState({ validInput: this.getValidationState.all() && this.checkChanged() })
-  }
-
-  touch = {
-    foodName: () => this.setState({ touched: { ...this.state.touched, foodName: true } }, this.validate),
-    foodCategory: () => this.setState({ touched: { ...this.state.touched, foodCategory: true } }, this.validate),
-    foodQuantity: () => this.setState({ touched: { ...this.state.touched, foodQuantity: true } }, this.validate),
-  }
-
-  /**
-   *  check whether newly edited values are different from the inital values
-   */
-   checkChanged = () => {
-     return Object.keys(this.state.modalInputFields).map(key =>
-       this.state.initialModalInputFields[key] !== this.state.modalInputFields[key]
-     ).reduce((acc, x) => acc || x, false)
-
-   }
-
-  /**
-   * functions to handle any changes of user input fields in the add/edit modal
-   */
-  handleChange = {
-    foodName: value => {
-      if (typeof value === 'string') {
-        // The user entered a food name that does not exist yet
-        this.setState({
-          modalInputFields: {
-            ...this.state.modalInputFields,
-            name: value,
-            categoryId: this.state.modalInputFields.categoryId
-          },
-        }, this.validate)
-      } else if (value !== null) {
-        // The user entered an existing food name and autosuggest provided the object for that food
-        this.setState({
-          modalInputFields: {
-            ...this.state.modalInputFields,
-            name: value ? value.name : "",
-            categoryId: value ? value.categoryId : ""
-          },
-        }, () => this.quantity.focus())
-      } else {
-        this.setState({
-          modalInputFields: {
-            ...this.state.modalInputFields,
-            name: "",
-            categoryId: this.state.modalInputFields.categoryId
-          },
-        }, this.validate)
-      }
-    },
-    foodQuantity: e =>
-      this.setState({ modalInputFields: { ...this.state.modalInputFields, quantity: e.target.value } }, this.validate),
-    foodCategory: e =>
-      this.setState({ modalInputFields: { ...this.state.modalInputFields, categoryId: e.target.value } }, this.validate)
-  }
-
-  saveFood = () => {
-    if (this.state.showModal === 'Edit' && this.state.editModalFood) {
-      this.props.saveFoodItem(
-        this.state.editModalFood.categoryId,
-        {
-          ...this.state.editModalFood,
-          name: this.state.modalInputFields.name,
-          categoryId: this.state.modalInputFields.categoryId,
-          quantity: this.state.modalInputFields.quantity
-        }
-      )
-    } else if (this.state.showModal === 'Add') {
-      this.props.saveFoodItem(
-        this.state.modalInputFields.categoryId,
-        {
-          name: this.state.modalInputFields.name,
-          categoryId: this.state.modalInputFields.categoryId,
-          quantity: this.state.modalInputFields.quantity
-        }
-      )
-    }
-  }
 
   updateSearchText = searchText => {
     if (searchText && searchText !== this.state.searchText) {
-      this.setState({searchText})
+      this.setState({ searchText })
     }
   }
 
-  handelModalSubmit = e => {
-    e.preventDefault()
-
-    if (this.state.validInput && !this.props.saving) {
-      this.saveFood()
-    }
-  }
-
-  renderSizePerPageDropDown = () => <SizePerPageDropDown variation='dropup'/>
+  renderSizePerPageDropDown = () => <SizePerPageDropDown variation='dropup' />
 
   render = () => {
     // set options for react-bootstrap-table
@@ -260,101 +124,41 @@ export class FoodItems extends React.Component {
       afterSearch: searchText => this.updateSearchText(searchText)
     }
     return (
-      <div>
-        <Box>
-          <BoxBody
-            // Don't show loading spinner or error message on main page when modal is showing
-            loading={this.state.showModal ? undefined : (this.props.loading || this.props.saving)}
-            error={this.state.showModal ? undefined : (this.props.loadError || this.props.saveError)}
-            errorBottom={true}>
-            <BootstrapTable data={this.props.foodItems} pagination keyField='_id' options={tableOptions} striped search>
-              <TableHeaderColumn dataField="name" dataSort>Name</TableHeaderColumn>
-              <TableHeaderColumn dataField="categoryId" dataSort dataFormat={this.categoryFormatter}>Category</TableHeaderColumn>
-              <TableHeaderColumn dataField="quantity" width='70px' dataAlign="right" dataSort>Qty</TableHeaderColumn>
-              <TableHeaderColumn width="140px" dataAlign="center" dataFormat={this.getActionButtons}></TableHeaderColumn>
-            </BootstrapTable>
-          </BoxBody>
-        </Box>
-
-        <Modal show={!!this.state.showModal} onHide={this.closeModal}>
-          <Box>
-            <BoxBody
-              loading={this.props.loading || this.props.saving}
-              error={this.props.saveError}
-              errorBottom={true}>
-              <Modal.Header closeButton>
-                <Modal.Title>{this.state.showModal} Food</Modal.Title>
-              </Modal.Header>
-              <Modal.Body>
-                <form onSubmit={this.handelModalSubmit}>
-                  <FormGroup controlId="foodName" validationState={this.getValidationState.foodName()} >
-                    <ControlLabel>Food Name</ControlLabel>
-                    <Autosuggest
-                      value={this.state.modalInputFields.name}
-                      datalist={this.props.foodItems}
-                      placeholder="Food Name"
-                      itemValuePropName='name'
-                      itemReactKeyPropName='name'
-                      itemSortKeyPropName='nameLowerCased'
-                      onSelect={this.handleChange.foodName}
-                      autoFocus={this.state.showModal === 'Add'}
-                      onFocus={this.touch.foodName}
-                    />
-                  </FormGroup>
-
-                  <FormGroup controlId="foodCategory" validationState={this.getValidationState.foodCategory()}>
-                    <ControlLabel>Category</ControlLabel>
-                    <FormControl componentClass="select" placeholder="select category"
-                      onChange={this.handleChange.foodCategory}
-                      value={this.state.modalInputFields.categoryId}
-                      autoFocus={this.state.showModal !== 'Add'}
-                      onFocus={this.touch.foodCategory}
-                    >
-                      {(this.state.showModal === 'Add') &&
-                        <option value="">Select Category</option>
-                      }
-                      {this.props.foodCategories.map(category =>
-                        <option key={category._id} value={category._id}>{category.category}</option>
-                      )}
-                    </FormControl>
-                  </FormGroup>
-
-                  <FormGroup controlId="foodQuantity" validationState={this.getValidationState.foodQuantity()} >
-                    <ControlLabel>Quantity</ControlLabel>
-                    <FormControl
-                      type="number"
-                      min="0"
-                      value={this.state.modalInputFields.quantity}
-                      placeholder="Quantity"
-                      onChange={this.handleChange.foodQuantity}
-                      onFocus={this.touch.foodQuantity}
-                      inputRef={ref => {this.quantity = ref}}
-                    />
-                  </FormGroup>
-                  <input type="submit" style={{ position: "absolute", left: "-9999px", width: "1px", height: "1px" }} />
-
-                </form>
-              </Modal.Body>
-              <Modal.Footer>
-                <Button onClick={this.closeModal}>Cancel</Button>
-                <Button className={this.state.validInput && 'btn-success'}
-                  onClick={this.saveFood}
-                  disabled={!this.state.validInput || this.props.saving}>
-                  {this.state.showModal === 'Add' ? 'Add' : 'Update'}
-                </Button>
-              </Modal.Footer>
-            </BoxBody>
-          </Box>
+      <Box>
+        <BoxBody
+          // Don't show loading spinner or error message on main page when modal is showing
+          loading={this.state.modalType ? undefined : (this.props.loading || this.props.saving)}
+          error={this.state.modalType ? undefined : (this.props.loadError || this.props.saveError)}
+          errorBottom={true}>
+          <BootstrapTable data={this.props.foodItems} pagination keyField='_id' options={tableOptions} striped search>
+            <TableHeaderColumn dataField="name" dataSort>Name</TableHeaderColumn>
+            <TableHeaderColumn dataField="categoryId" dataSort dataFormat={this.categoryFormatter}>Category</TableHeaderColumn>
+            <TableHeaderColumn dataField="quantity" width='70px' dataAlign="right" dataSort>Qty</TableHeaderColumn>
+            <TableHeaderColumn width="140px" dataAlign="center" dataFormat={this.getActionButtons}></TableHeaderColumn>
+          </BootstrapTable>
+        </BoxBody>
+        <Modal show={!!this.state.modalType} onHide={this.closeModal}>
+          <FoodAddEditForm
+            foodItems={this.props.foodItems}
+            foodCategories={this.props.foodCategories}
+            loading={this.props.loading}
+            saving={this.props.saving}
+            saveError={this.props.saveError}
+            saveFoodItem={this.props.saveFoodItem}
+            formType={this.state.modalType}
+            editFood={this.state.editModalFood}
+            closeModal={this.closeModal}
+          />
         </Modal>
-      </div>)
+      </Box>
+    )
   }
-
 }
 
 const mapStateToProps = state => ({
   // Add a nameLowerCased property with the name in lower case to use for sorting in autosuggest
   foodItems: selectors.food.item.getAll(state).map(item =>
-    ({...item, nameLowerCased: item.name.toLowerCase()})),
+    ({ ...item, nameLowerCased: item.name.toLowerCase() })),
   foodCategories: selectors.food.category.getAll(state),
   loading: selectors.food.category.loading(state),
   loadError: selectors.food.category.loadError(state),
@@ -366,7 +170,7 @@ const mapDispatchToProps = dispatch => ({
   saveFoodItem: (categoryId, foodItem) => dispatch(saveFoodItem(categoryId, foodItem)),
   deleteFoodItem: (categoryId, _id) => dispatch(deleteFoodItem(categoryId, _id)),
   clearFlags: () => dispatch(clearFlags()),
-  hideDialog : () => dispatch(hideDialog()),
+  hideDialog: () => dispatch(hideDialog()),
   showConfirmDialog: (cancel, confirm, message, label) =>
     dispatch(showConfirmDialog(cancel, confirm, message, label)),
 })

--- a/client/modules/food/components/inventory/FoodItems.spec.js
+++ b/client/modules/food/components/inventory/FoodItems.spec.js
@@ -21,61 +21,17 @@ describe('FoodItems', () => {
 
   it('sets state when constructed', () => {
     const wrapper = shallow(<FoodItems {...props} />)
-    expect(wrapper.state().showModal).to.equal(false)
+    expect(wrapper.state().modalType).to.equal(undefined)
     expect(wrapper.state().editModalFood).to.equal(undefined)
-    expect(wrapper.state().modalInputFields).to.deep.equal({ name: "", categoryId: "", quantity: "" })
-    expect(wrapper.state().validInput).to.equal(false)
-    expect(wrapper.state().initialModalInputFields).to.deep.equal({ name: "", categoryId: "", quantity: "" })
+    expect(wrapper.state().searchText).to.equal("")
   })
 
-  it('componentWillReceiveProps closes modal if a save is complete', () => {
-    const wrapper = shallow(<FoodItems {...props} />)
-    wrapper.setProps({ saving: true })
-    const instance = wrapper.instance()
-    sinon.spy(instance, "closeModal")
-    instance.setState({ showModal: true })
-    const nextProps = {
-      saving: false,
-      saveError: undefined
-    }
-    instance.componentWillReceiveProps(nextProps)
-    expect(instance.closeModal.called).to.be.true
-  })
-
-  it('componentWillReceiveProps will not close a modal if in process of saving', () => {
-    const wrapper = shallow(<FoodItems {...props} />)
-    wrapper.setProps({ saving: false })
-    const instance = wrapper.instance()
-    sinon.spy(instance, "closeModal")
-    instance.setState({ showModal: true })
-    const nextProps = {
-      saving: true,
-    }
-    instance.componentWillReceiveProps(nextProps)
-    expect(instance.closeModal.called).to.be.false
-  })
-
-  it('componentWillReceiveProps will not close a modal if there is a save error', () => {
-    const wrapper = shallow(<FoodItems {...props} />)
-    wrapper.setProps({ saving: true })
-    const instance = wrapper.instance()
-    sinon.spy(instance, "closeModal")
-    instance.setState({ showModal: true })
-    const nextProps = {
-      saving: false,
-      saveError: { message: 'error' }
-    }
-    instance.componentWillReceiveProps(nextProps)
-    expect(instance.closeModal.called).to.be.false
-  })
-
-  it('openModal sets the showModal, editModalFood and modalInput fields to add mode', () => {
+  it('openModal sets the showModal and editModalFood to add mode', () => {
     const wrapper = shallow(<FoodItems {...props} />)
     const instance = wrapper.instance()
     instance.openModal()()
-    expect(instance.state.showModal).to.eql('Add')
+    expect(instance.state.modalType).to.eql('Add')
     expect(instance.state.editModalFood).to.equal(undefined)
-    expect(instance.state.modalInputFields).to.deep.equal({ name: "", categoryId: "", quantity: "" })
   })
 
   it('openModal sets the showModal, editModalFood and modalInput fields to edit mode', () => {
@@ -88,9 +44,8 @@ describe('FoodItems', () => {
     })
     const instance = wrapper.instance()
     instance.openModal('456')()
-    expect(instance.state.showModal).to.eql('Edit')
+    expect(instance.state.modalType).to.eql('Edit')
     expect(instance.state.editModalFood).to.deep.equal({ _id: '456', name: 'banana', quantity: 13, categoryId: '66' })
-    expect(instance.state.modalInputFields).to.deep.equal({ name: "banana", categoryId: "66", quantity: "13" })
   })
 
   it('openModal calls props.clearFlags', () => {
@@ -100,7 +55,7 @@ describe('FoodItems', () => {
     expect(instance.props.clearFlags.called).to.be.true
   })
 
-  it('closeModal sets the showModal, editModalFood, modalInput and validInput fields', () => {
+  it('closeModal sets the modalType and editModalFood to undefined', () => {
     const wrapper = shallow(<FoodItems {...props} />)
     wrapper.setProps({
       foodItems: [
@@ -110,10 +65,8 @@ describe('FoodItems', () => {
     const instance = wrapper.instance()
     instance.openModal('456')()
     instance.closeModal()
-    expect(instance.state.showModal).to.be.false
+    expect(instance.state.modalType).to.equal(undefined)
     expect(instance.state.editModalFood).to.equal(undefined)
-    expect(instance.state.modalInputFields).to.deep.equal({ name: "", categoryId: "", quantity: "" })
-    expect(instance.state.validInput).to.be.false
   })
 
   it('closeModal calls props.clearFlags', () => {
@@ -259,363 +212,18 @@ describe('FoodItems', () => {
     })
   })
 
-  describe('getValidationState', () => {
-    it('foodName() returns null for a valid name', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc' } })
-      expect(instance.getValidationState.foodName()).to.be.null
-    })
-
-    it('foodName() returns error for an empty string', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: '' }, touched: { foodName: true } })
-      expect(instance.getValidationState.foodName()).to.equal('error')
-    })
-
-    it('foodName() returns error for a whitespace string', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: ' ' }, touched: { foodName: true } })
-      expect(instance.getValidationState.foodName()).to.equal('error')
-    })
-
-    it('foodQuantity() returns null for 0', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', quantity: '0' }, touched: { foodQuantity: true } })
-      expect(instance.getValidationState.foodQuantity()).to.be.null
-    })
-
-    it('foodQuantity() returns null for 1', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', quantity: '1' }, touched: { foodQuantity: true } })
-      expect(instance.getValidationState.foodQuantity()).to.be.null
-    })
-
-    it('foodQuantity() returns null for 623', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', quantity: '623' }, touched: { foodQuantity: true } })
-      expect(instance.getValidationState.foodQuantity()).to.be.null
-    })
-
-    it('foodQuantity() returns error for -1', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', quantity: '-1' }, touched: { foodQuantity: true } })
-      expect(instance.getValidationState.foodQuantity()).to.equal('error')
-    })
-
-    it('foodQuantity() returns error for an empty string', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', quantity: '' }, touched: { foodQuantity: true } })
-      expect(instance.getValidationState.foodQuantity()).to.equal('error')
-    })
-
-    it('foodQuantity() returns error for a non-numeric string', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', quantity: 'a1' }, touched: { foodQuantity: true } })
-      expect(instance.getValidationState.foodQuantity()).to.equal('error')
-    })
-
-    it('foodCategory() returns null for a non-empty string', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', categoryId: '11' }, touched: { foodCategory: true } })
-      expect(instance.getValidationState.foodCategory()).to.be.null
-    })
-
-    it('foodCategory() returns error for an empty string', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      instance.setState({ modalInputFields: { name: 'abc', categoryId: '' }, touched: { foodCategory: true } })
-      expect(instance.getValidationState.foodCategory()).to.equal('error')
-    })
-
-    it('getAll() returns true when name, category and quantity are all valid', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      const state = {
-        modalInputFields: { name: 'abc', categoryId: '12', quantity: '5' },
-        touched: { foodName: true, foodCategory: true, foodQuantity: true }
-      }
-      instance.setState(state)
-      expect(instance.getValidationState.all()).to.be.true
-    })
-
-    it('getAll() returns false when name is not valid', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      const state = {
-        modalInputFields: { name: '', categoryId: '12', quantity: '5' },
-        touched: { foodName: true, foodCategory: true, foodQuantity: true }
-      }
-      instance.setState(state)
-      expect(instance.getValidationState.all()).to.be.false
-    })
-
-    it('getAll() returns false when category is not valid', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      const state = {
-        modalInputFields: { name: 'abc', categoryId: '', quantity: '5' },
-        touched: { foodName: true, foodCategory: true, foodQuantity: true }
-      }
-      instance.setState(state)
-      expect(instance.getValidationState.all()).to.be.false
-    })
-
-    it('getAll() returns false when quantity is not valid', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      const state = {
-        modalInputFields: { name: 'abc', categoryId: '12', quantity: '-5' },
-        touched: { foodName: true, foodCategory: true, foodQuantity: true }
-      }
-      instance.setState(state)
-      expect(instance.getValidationState.all()).to.be.false
-    })
-
-  })
-
-  describe('validate()', () => {
-    it('sets state.validInput true when getValidationState.all() and checkChanged()', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      sinon.stub(instance.getValidationState, "all").callsFake(() => true)
-      sinon.stub(instance, "checkChanged").callsFake(() => true)
-      instance.validate()
-      expect(instance.state.validInput).to.equal(true)
-    })
-
-    it('sets state.validInput false when !getValidationState.all() and checkChanged()', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      sinon.stub(instance.getValidationState, "all").callsFake(() => false)
-      sinon.stub(instance, "checkChanged").callsFake(() => true)
-      instance.validate()
-      expect(instance.state.validInput).to.equal(false)
-    })
-
-    it('sets state.validInput false when getValidationState.all() and !checkChanged()', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      sinon.stub(instance.getValidationState, "all").callsFake(() => true)
-      sinon.stub(instance, "checkChanged").callsFake(() => false)
-      instance.validate()
-      expect(instance.state.validInput).to.equal(false)
-    })
-
-    it('sets state.validInput false when !getValidationState.all() and !checkChanged()', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      sinon.stub(instance.getValidationState, "all").callsFake(() => false)
-      sinon.stub(instance, "checkChanged").callsFake(() => false)
-      instance.validate()
-      expect(instance.state.validInput).to.equal(false)
-    })
-  })
-
-  describe('touch()', () => {
-    it('touch.foodName() sets state touched.foodName to true', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.setState({ touched: { foodName: false } })
-      instance.touch.foodName()
-      expect(instance.state.touched.foodName).to.be.true
-    })
-
-    it('touch.foodCategory() sets state touched.foodCategory to true', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.setState({ touched: { foodCategory: false } })
-      instance.touch.foodCategory()
-      expect(instance.state.touched.foodCategory).to.be.true
-    })
-
-    it('touch.foodQuantity() sets state touched.foodQuantity to true', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.setState({ touched: { foodQuantity: false } })
-      instance.touch.foodQuantity()
-      expect(instance.state.touched.foodQuantity).to.be.true
-    })
-  })
-
-  describe('checkChanged()', () => {
-    it('is false when modalInputFields are the same as initialModalInputFields', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      const state = {
-        initialModalInputFields: { name: 'abc', quantity: '5' },
-        modalInputFields: { name: 'abc', quantity: '5' }
-      }
-      instance.setState(state)
-      expect(instance.checkChanged()).to.be.false
-    })
-
-    it('is true when modalInputFields differ from initialModalInputFields', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      const state = {
-        initialModalInputFields: { name: 'abc', quantity: '5' },
-        modalInputFields: { name: 'abc', quantity: '15' }
-      }
-      instance.setState(state)
-      expect(instance.checkChanged()).to.be.true
-    })
-  })
-
-  describe('handleChange', () => {
-    it('foodName() when called with a string sets state.modalInputFields.name', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.handleChange.foodName('abcde')
-      expect(instance.state.modalInputFields.name).to.equal('abcde')
-    })
-
-    it('foodName() when called with a string calls validate()', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      sinon.spy(instance, "validate")
-      instance.handleChange.foodName('abcde')
-      expect(instance.validate.called).to.be.true
-    })
-
-    it('foodName() when called with an object calls this.quantity.focus()', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.quantity = { focus: sinon.spy() }
-      instance.handleChange.foodName({ name: 'xyz', categoryId: '5832' })
-      expect(instance.quantity.focus.called).to.be.true
-
-    })
-
-    it('foodName() when called with an object sets name and categoryId', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.quantity = { focus: () => { } }
-      instance.handleChange.foodName({ name: 'xyz', categoryId: '5832' })
-      expect(instance.state.modalInputFields.name).to.equal('xyz')
-      expect(instance.state.modalInputFields.categoryId).to.equal('5832')
-    })
-
-    it('foodName() when called with null sets state.modalInputFields.name to ""', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.setState({ modalInputFields: { name: 'abc' } })
-      instance.handleChange.foodName(null)
-      expect(instance.state.modalInputFields.name).to.equal("")
-    })
-
-    it('foodName() when called with null calls validate()', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      sinon.spy(instance, "validate")
-      instance.handleChange.foodName(null)
-      expect(instance.validate.called).to.be.true
-    })
-
-    it('foodQuantity() sets state.modalInputFields.quantity', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.handleChange.foodQuantity({ target: { value: '20' } })
-      expect(instance.state.modalInputFields.quantity).to.equal('20')
-    })
-
-    it('foodQuantity() calls validate()', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      sinon.spy(instance, "validate")
-      instance.handleChange.foodQuantity({ target: { value: '20' } })
-      expect(instance.validate.called).to.be.true
-    })
-
-    it('foodCategory() sets state.modalInputFields.categoryId', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      instance.handleChange.foodCategory({ target: { value: '3732' } })
-      expect(instance.state.modalInputFields.categoryId).to.equal('3732')
-    })
-
-    it('foodCategory() calls validate()', () => {
-      const instance = shallow(<FoodItems {...props} />).instance()
-      sinon.spy(instance, "validate")
-      instance.handleChange.foodCategory({ target: { value: '42623' } })
-      expect(instance.validate.called).to.be.true
-    })
-
-
-  })
-
-  describe('saveFood()', () => {
-    it('Calls props.saveFoodItem() when an edit modal is open', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      wrapper.setProps({ saveFoodItem: sinon.spy() })
-      const instance = wrapper.instance()
-      instance.setState({
-        showModal: 'Edit',
-        editModalFood: { id: '123', categoryId: '456' },
-        modalInputFields: { name: 'abc', categoryId: '789', quantity: '42' }
-      })
-      instance.saveFood()
-      expect(instance.props.saveFoodItem.called).to.be.true
-      expect(instance.props.saveFoodItem.args[0][0]).to.equal('456')
-      expect(instance.props.saveFoodItem.args[0][1]).to.deep.equal({ id: '123', name: 'abc', categoryId: '789', quantity: '42' })
-    })
-
-    it('Calls props.saveFoodItem() when an add modal is open', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      wrapper.setProps({ saveFoodItem: sinon.spy() })
-      const instance = wrapper.instance()
-      instance.setState({
-        showModal: 'Add',
-        modalInputFields: { name: 'abc', categoryId: '123', quantity: '42' }
-      })
-      instance.saveFood()
-      expect(instance.props.saveFoodItem.called).to.be.true
-      expect(instance.props.saveFoodItem.args[0][0]).to.equal('123')
-      expect(instance.props.saveFoodItem.args[0][1]).to.deep.equal({ name: 'abc', categoryId: '123', quantity: '42' })
-    })
-  })
-
-  describe('handleSubmit()', () => {
-    it('calls saveFood when validInput and not saving', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      wrapper.setProps({ saving: false })
-      const instance = wrapper.instance()
-      sinon.spy(instance, "saveFood")
-      instance.setState({ validInput: true })
-      const e = { preventDefault: () => { } }
-      instance.handelModalSubmit(e)
-      expect(instance.saveFood.called).to.be.true
-    })
-
-    it('does not call saveFood when not validInput', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      const instance = wrapper.instance()
-      sinon.spy(instance, "saveFood")
-      instance.setState({ validInput: false })
-      const e = { preventDefault: () => { } }
-      instance.handelModalSubmit(e)
-      expect(instance.saveFood.called).to.be.false
-    })
-    it('does not call saveFood when saving', () => {
-      const wrapper = shallow(<FoodItems {...props} />)
-      wrapper.setProps({ saving: true })
-      const instance = wrapper.instance()
-      sinon.spy(instance, "saveFood")
-      instance.setState({ validInput: true })
-      const e = { preventDefault: () => { } }
-      instance.handelModalSubmit(e)
-      expect(instance.saveFood.called).to.be.false
-    })
-
-  })
-
   describe('render()', () => {
-    it('hides modal when state.showModal is false, shows when "Add" or "Edit"', () => {
+    it('hides modal when state.modalType is undefined, shows when "Add" or "Edit"', () => {
       let wrapper = mount(<FoodItems {...props} />)
 
       let modal = wrapper.find(Modal)
       expect(modal.length).to.equal(1)
       expect(modal.props().show).to.be.false
-      wrapper.setState({ showModal: 'Add' })
+      wrapper.setState({ modalType: 'Add' })
       expect(modal.props().show).to.be.true
-      wrapper.setState({ showModal: false })
+      wrapper.setState({ modalType: undefined })
       expect(modal.props().show).to.be.false
-      wrapper.setState({ showModal: 'Edit' })
+      wrapper.setState({ modalType: 'Edit' })
       expect(modal.props().show).to.be.true
     })
 


### PR DESCRIPTION
I think the FoodItem.js component is doing too much and the code is hard to reason with.  So I kept the functionality for listing the food items in that file and moved all the functionality dealing with the form for adding and editing foods into a new FoodAddEditForm component.