### PR TITLE
Feature - Add Tooltip to Packed Package List Preferred Foods

### DIFF
--- a/client/modules/food/components/packing/PackingList.js
+++ b/client/modules/food/components/packing/PackingList.js
@@ -5,7 +5,7 @@ const  MIN_DAYS_SINCE_LAST_PACKED_TO_SHOW = 7
 import React, {Component} from 'react'
 import {connect} from 'react-redux'
 import {compose, withProps} from 'recompose'
-import {Button} from 'react-bootstrap'
+import {Button, Tooltip, OverlayTrigger} from 'react-bootstrap'
 import {BootstrapTable, TableHeaderColumn, SizePerPageDropDown} from 'react-bootstrap-table'
 import 'react-bootstrap-table/dist/react-bootstrap-table.min.css'
 
@@ -75,7 +75,18 @@ class PackingList extends Component {
     this.props.packSelected(packages)
   }
 
-  getItemList = items => items.map(i => i.name).join(', ')
+  tooltip = content => (
+    <Tooltip id="tooltip">{content}</Tooltip>
+  )
+
+  getItemList = items => {
+    const content = items.map(i => i.name).join(', ')
+    return (
+      <OverlayTrigger placement="top" overlay={this.tooltip(content)}>
+        <div>{content}</div>
+      </OverlayTrigger>
+    )
+  }
 
   select(props) {
     const {type, checked, disabled, onChange, rowIndex} = props


### PR DESCRIPTION
closes #356 

The module for the table `react-bootstrap-table` doesn't have a nice way of attaching listeners to cells. I wrapped the contents of each cell with an `OverlayTrigger`. Not sure if this adds too much extra markup.