### PR TITLE
fix: signup form validation issue

### DIFF
--- a/client/modules/users/UserRouter.js
+++ b/client/modules/users/UserRouter.js
@@ -20,6 +20,7 @@ import './css/users.css'
 
 const IsAdmin = requireRole([ADMIN_ROLE])
 const guestOrRedirectSignIn = guestOrRedirect(SignIn)
+const guestOrRedirectSignUp = guestOrRedirect(SignUp)
 
 const UserRouter = ({match}) =>
   <SwitchWithNotFound>
@@ -54,7 +55,7 @@ const UserRouter = ({match}) =>
       component={ResetPassword}
     />
     <Route path={`${match.url}/signin`} exact component={guestOrRedirectSignIn} />
-    <Route path={`${match.url}/signup`} exact component={guestOrRedirect(SignUp)} />
+    <Route path={`${match.url}/signup`} exact component={guestOrRedirectSignUp} />
     <Route
       path={`${match.url}/confirm-new-google-account`}
       exact


### PR DESCRIPTION
Added a fix similar to the one implemented for issue #370 to ensure that the signup form is not cleared when an invalid email address is entered, and the incorrect email error is properly shown.

closes #372