### PR TITLE
removed unused path and route props in Header

### DIFF
--- a/client/modules/core/components/Header.js
+++ b/client/modules/core/components/Header.js
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 
 import {connect} from 'react-redux'
-import {trim} from 'lodash'
 
 import {ADMIN_ROLE} from '../../../../common/constants'
 import selectors from '../../../store/selectors'
@@ -11,27 +10,20 @@ import AdminNavbar from './navbar/AdminNavbar'
 
 const mapStateToProps = state => ({
   user: selectors.auth.getUser(state),
-  route: state.router.location,
   settings: selectors.settings.getSettings(state)
 })
 
-const Header = ({settings, user, route}) => {
-  const path = trim(route.pathname, '/')
+const Header = ({settings, user}) => {
   const isAdmin = user && user.roles.find(r => r === ADMIN_ROLE)
 
   return isAdmin ?
     <AdminNavbar user={user} settings={settings} /> :
-    <ClientNavbar
-      user={user}
-      settings={settings}
-      path={path}
-    />
+    <ClientNavbar user={user} settings={settings} />
 }
 
 Header.propTypes = {
   settings: PropTypes.object,
   user: PropTypes.object,
-  route: PropTypes.object.isRequired
 }
 
 export default connect(mapStateToProps)(Header)


### PR DESCRIPTION
I removed the route and path props from the Header component because the Navbar wasn't using the path property being passed to it.  And the route prop was only used for getting the path.