### PR TITLE
remove unused withRouter from Sidebar

### DIFF
--- a/client/modules/core/components/sidebar/Sidebar.js
+++ b/client/modules/core/components/sidebar/Sidebar.js
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import {connect} from 'react-redux'
-import {withRouter} from 'react-router-dom'
 
 import {ADMIN_ROLE} from '../../../../../common/constants'
 import selectors from '../../../../store/selectors'
@@ -30,4 +29,4 @@ Sidebar.propTypes = {
   })
 }
 
-export default withRouter(connect(mapStateToProps)(Sidebar))
+export default connect(mapStateToProps)(Sidebar)


### PR DESCRIPTION
withRouter is not needed on the Sidebar component because it doesn't use any props from provided by it