### PR TITLE
Include setWaypoints reducer in CustomerSelector

### DIFF
--- a/client/modules/driver/components/driver-assignment/CustomerSelector.js
+++ b/client/modules/driver/components/driver-assignment/CustomerSelector.js
@@ -6,7 +6,7 @@ import {Checkbox} from '../../../../components/form'
 import selectors from '../../../../store/selectors'
 import getAddress from '../../../../lib/get-address'
 import {setFilter, selectCustomers, toggleCustomer} from '../../reducers/assignment'
-import {addWaypoints, removeWaypoints} from '../../reducers/route'
+import {addWaypoints, removeWaypoints, setWaypoints} from '../../reducers/route'
 import FilterCustomers from './FilterCustomers'
 
 const mapStateToProps = state => ({
@@ -24,7 +24,8 @@ const mapDispatchToProps = dispatch => ({
   selectCustomers: customers => dispatch(selectCustomers(customers)),
   handleFilterChange: ev => dispatch(setFilter(ev.target.value)),
   addWaypoints: waypoints => dispatch(addWaypoints(waypoints)),
-  removeWaypoints: waypoints => dispatch(removeWaypoints(waypoints))
+  removeWaypoints: waypoints => dispatch(removeWaypoints(waypoints)),
+  setWaypoints: waypoints => dispatch(setWaypoints(waypoints))
 })
 
 const mergeProps = (stateProps, dispatchProps) => ({
@@ -37,7 +38,7 @@ const mergeProps = (stateProps, dispatchProps) => ({
   },
   handleDeselectAll: () => {
     dispatchProps.selectCustomers([]) // TODO: deselect only visible selected customers
-    dispatchProps.setWaypoints([]) //removeWaypoints(stateProps.customers)
+    dispatchProps.setWaypoints([])
   },
   handleSelect: id => () => {
     const customer = stateProps.getCustomer(id)


### PR DESCRIPTION
 For deselect all customers on route assignment page.

Previously, clicking deselect all would give a console error:
vendor.js:1 Uncaught TypeError: t.setWaypoints is not a function
    at handleDeselectAll (app.js:1)
    at Object.executeOnChange (vendor.js:1)
    at Q.<anonymous> (vendor.js:1)
    at Object.o (vendor.js:1)
    at s (vendor.js:1)
    at Object.executeDispatchesInOrder (vendor.js:1)
    at p (vendor.js:1)
    at d (vendor.js:1)
    at Array.forEach (<anonymous>)
    at e.exports (vendor.js:1)

setWaypoints was already defined in the redux file.  This PR includes the setWaypoints reducer in CustomerSelector and adds it to dispatchProps.