### PR TITLE
Remove server unit tests folder

### DIFF
--- a/server/routes/api.spec.js
+++ b/server/routes/api.spec.js
@@ -1,6 +1,6 @@
-import apiRouterFactory from '../../routes/api'
+import apiRouterFactory from './api'
 
-import {ADMIN_ROLE} from '../../../common/constants'
+import {ADMIN_ROLE} from '../../common/constants'
 
 describe('Api router', function() {
   let userControllerMock


### PR DESCRIPTION
To conform with the project convention of putting the tests in the same folder as the files they're testing, move the one test in server/test/unit to routes folder and remove the folder server/test/unit.